### PR TITLE
SK-1736: Fix inconsistencies

### DIFF
--- a/skyflow/service_account/_utils.py
+++ b/skyflow/service_account/_utils.py
@@ -5,7 +5,7 @@ import jwt
 from skyflow.error import SkyflowError
 from skyflow.generated.rest.models import V1GetAuthTokenRequest
 from skyflow.service_account.client.auth_client import AuthClient
-from skyflow.utils.logger import log_error, log_info, log_error_log, Logger
+from skyflow.utils.logger import log_info, log_error_log
 from skyflow.utils import get_base_url, format_scope, SkyflowMessages
 
 
@@ -115,7 +115,7 @@ def get_signed_jwt(options, client_id, key_id, token_uri, private_key, logger):
 
 def get_signed_tokens(credentials_obj, options):
     try:
-        expiry_time = time.time() + options.get("time_to_live", 60)
+        expiry_time = int(time.time()) + options.get("time_to_live", 60)
         prefix = "signed_token_"
 
         if options and options.get("data_tokens"):
@@ -123,10 +123,10 @@ def get_signed_tokens(credentials_obj, options):
                 claims = {
                     "iss": "sdk",
                     "key": credentials_obj.get("keyID"),
-                    "aud": credentials_obj.get("tokenURI"),
                     "exp": expiry_time,
                     "sub": credentials_obj.get("clientID"),
-                    "tok": token
+                    "tok": token,
+                    "iat": int(time.time()),
                 }
 
                 if "ctx" in options:

--- a/skyflow/vault/controller/_vault.py
+++ b/skyflow/vault/controller/_vault.py
@@ -2,7 +2,7 @@ from skyflow.generated.rest import V1FieldRecords, RecordServiceInsertRecordBody
     V1DetokenizePayload, V1TokenizeRecordRequest, V1TokenizePayload, QueryServiceExecuteQueryBody, \
     RecordServiceBulkDeleteRecordBody, RecordServiceUpdateRecordBody, RecordServiceBatchOperationBody, V1BatchRecord, \
     BatchRecordMethod
-from skyflow.generated.rest.exceptions import BadRequestException, UnauthorizedException
+from skyflow.generated.rest.exceptions import BadRequestException, UnauthorizedException, ForbiddenException
 from skyflow.utils import SkyflowMessages, parse_insert_response, \
     handle_exception, parse_update_record_response, parse_delete_response, parse_detokenize_response, \
     parse_tokenize_response, parse_query_response, parse_get_response, encode_column_values
@@ -105,6 +105,8 @@ class Vault:
             handle_exception(e, self.__vault_client.get_logger())
         except UnauthorizedException as e:
             handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
+            handle_exception(e, self.__vault_client.get_logger())
 
     def update(self, request: UpdateRequest):
         log_info(SkyflowMessages.Info.VALIDATE_UPDATE_REQUEST.value, self.__vault_client.get_logger())
@@ -132,6 +134,8 @@ class Vault:
             handle_exception(e, self.__vault_client.get_logger())
         except UnauthorizedException as e:
             handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
+            handle_exception(e, self.__vault_client.get_logger())
 
     def delete(self, request: DeleteRequest):
         log_info(SkyflowMessages.Info.VALIDATING_DELETE_REQUEST.value, self.__vault_client.get_logger())
@@ -156,6 +160,8 @@ class Vault:
         except UnauthorizedException as e:
             log_error_log(SkyflowMessages.ErrorLogs.DELETE_REQUEST_REJECTED.value,
                           logger=self.__vault_client.get_logger())
+            handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
             handle_exception(e, self.__vault_client.get_logger())
 
     def get(self, request: GetRequest):
@@ -190,6 +196,8 @@ class Vault:
         except UnauthorizedException as e:
             log_error_log(SkyflowMessages.ErrorLogs.GET_REQUEST_REJECTED.value, self.__vault_client.get_logger())
             handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
+            handle_exception(e, self.__vault_client.get_logger())
 
     def query(self, request: QueryRequest):
         log_info(SkyflowMessages.Info.VALIDATING_QUERY_REQUEST.value, self.__vault_client.get_logger())
@@ -212,6 +220,8 @@ class Vault:
             handle_exception(e, self.__vault_client.get_logger())
         except UnauthorizedException as e:
             log_error_log(SkyflowMessages.ErrorLogs.QUERY_REQUEST_REJECTED.value, self.__vault_client.get_logger())
+            handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
             handle_exception(e, self.__vault_client.get_logger())
 
     def detokenize(self, request: DetokenizeRequest):
@@ -241,6 +251,8 @@ class Vault:
             log_error_log(SkyflowMessages.ErrorLogs.DETOKENIZE_REQUEST_REJECTED.value,
                           logger=self.__vault_client.get_logger())
             handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
+            handle_exception(e, self.__vault_client.get_logger())
 
     def tokenize(self, request: TokenizeRequest):
         log_info(SkyflowMessages.Info.VALIDATING_TOKENIZE_REQUEST.value, self.__vault_client.get_logger())
@@ -269,4 +281,6 @@ class Vault:
         except UnauthorizedException as e:
             log_error_log(SkyflowMessages.ErrorLogs.TOKENIZE_REQUEST_REJECTED.value,
                           logger=self.__vault_client.get_logger())
+            handle_exception(e, self.__vault_client.get_logger())
+        except ForbiddenException as e:
             handle_exception(e, self.__vault_client.get_logger())


### PR DESCRIPTION
**Why**
The signed bearer token generation has an issue with the expiry date, causing failures in E2E tests. Additionally, there is a need to handle forbidden exceptions for Vault APIs more effectively.

**Goal**
- Ensure E2E tests run successfully without interruptions due to token expiry issues.
- Provide clear and actionable error handling for forbidden exceptions in Vault APIs.