### PR TITLE
SK-1889: Add request Ids in response for continue on error failures

### DIFF
--- a/skyflow/generated/rest/api/tokens_api.py
+++ b/skyflow/generated/rest/api/tokens_api.py
@@ -174,6 +174,7 @@ class TokensApi:
 
         _response_types_map: Dict[str, Optional[str]] = {
             '200': "V1DetokenizeResponse",
+            '207': "V1DetokenizeResponse",
             '404': "object",
         }
         response_data = self.api_client.call_api(

--- a/skyflow/utils/_utils.py
+++ b/skyflow/utils/_utils.py
@@ -194,8 +194,8 @@ def parse_insert_response(api_response, continue_on_error):
     inserted_fields = []
     errors = []
     insert_response = InsertResponse()
-    response_data = json.loads(api_response.raw_data.decode('utf-8'))
     if continue_on_error:
+        response_data = json.loads(api_response.raw_data.decode('utf-8'))
         for idx, response in enumerate(response_data.get('responses', [])):
             if response['Status'] == 200:
                 body = response['Body']
@@ -221,7 +221,7 @@ def parse_insert_response(api_response, continue_on_error):
             insert_response.errors = errors
 
     else:
-        for record in response_data.get('records', []):
+        for record in api_response.records:
             field_data = {
                 'skyflow_id': record.skyflow_id
             }

--- a/skyflow/utils/enums/env.py
+++ b/skyflow/utils/enums/env.py
@@ -1,13 +1,13 @@
 from enum import Enum
 
 class Env(Enum):
-    DEV = 'DEV',
-    SANDBOX = 'SANDBOX',
+    DEV = 'DEV'
+    SANDBOX = 'SANDBOX'
     PROD = 'PROD'
     STAGE = 'STAGE'
 
 class EnvUrls(Enum):
-    PROD = "vault.skyflowapis.com",
-    SANDBOX = "vault.skyflowapis-preview.com",
+    PROD = "vault.skyflowapis.com"
+    SANDBOX = "vault.skyflowapis-preview.com"
     DEV = "vault.skyflowapis.dev"
     STAGE = "vault.skyflowapis.tech"

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -514,15 +514,15 @@ def validate_detokenize_request(logger, request):
         raise SkyflowError(SkyflowMessages.Error.EMPTY_TOKENS_LIST_VALUE.value, invalid_input_error_code)
 
     for item in request.data:
-        if 'token' not in item or 'redaction' not in item:
+        if 'token' not in item:
             raise SkyflowError(SkyflowMessages.Error.INVALID_TOKENS_LIST_VALUE.value(type(request.data)), invalid_input_error_code)
         token = item.get('token')
-        redaction = item.get('redaction')
+        redaction = item.get('redaction', RedactionType.PLAIN_TEXT)
 
         if not isinstance(token, str) or not token:
             raise SkyflowError(SkyflowMessages.Error.INVALID_TOKEN_TYPE.value.format("DETOKENIZE"), invalid_input_error_code)
 
-        if not isinstance(redaction, RedactionType) or not redaction:
+        if redaction is not None and not isinstance(redaction, RedactionType):
             raise SkyflowError(SkyflowMessages.Error.INVALID_REDACTION_TYPE.value.format(type(redaction)), invalid_input_error_code)
 
 def validate_tokenize_request(logger, request):

--- a/tests/utils/test__utils.py
+++ b/tests/utils/test__utils.py
@@ -262,11 +262,13 @@ class TestUtils(unittest.TestCase):
 
     def test_parse_detokenize_response_with_mixed_records(self):
         mock_api_response = Mock()
-        mock_api_response.records = [
+        mock_api_response.data = Mock()  # Ensure `data` exists
+        mock_api_response.data.records = [
             Mock(token="token1", value="value1", value_type=Mock(value="Type1"), error=None),
             Mock(token="token2", value=None, value_type=None, error="Some error"),
             Mock(token="token3", value="value3", value_type=Mock(value="Type2"), error=None),
         ]
+        mock_api_response.headers = {"x-request-id": "test-request-id"}  # Mock headers
 
         result = parse_detokenize_response(mock_api_response)
         self.assertIsInstance(result, DetokenizeResponse)
@@ -277,7 +279,7 @@ class TestUtils(unittest.TestCase):
         ]
 
         expected_errors = [
-            {"token": "token2", "error": "Some error"}
+            {"request_id": "test-request-id", "token": "token2", "error": "Some error"}
         ]
 
         self.assertEqual(result.detokenized_fields, expected_detokenized_fields)

--- a/tests/utils/test__utils.py
+++ b/tests/utils/test__utils.py
@@ -183,13 +183,23 @@ class TestUtils(unittest.TestCase):
 
     def test_parse_insert_response(self):
         api_response = Mock()
-        api_response.responses = [
-            {"Status": 200, "Body": {"records": [{"skyflow_id": "id1"}]}},
-            {"Status": 400, "Body": {"error": TEST_ERROR_MESSAGE}}
-        ]
+
+        api_response.raw_data = json.dumps({
+            "responses": [
+                {"Status": 200, "Body": {"records": [{"skyflow_id": "id1"}]}},
+                {"Status": 400, "Body": {"error": "TEST_ERROR_MESSAGE"}}
+            ]
+        }).encode('utf-8')
+
+        api_response.headers = {"x-request-id": "test-request-id"}
+
         result = parse_insert_response(api_response, continue_on_error=True)
+
         self.assertEqual(len(result.inserted_fields), 1)
         self.assertEqual(len(result.errors), 1)
+        self.assertEqual(result.inserted_fields[0]['skyflow_id'], "id1")
+        self.assertEqual(result.errors[0]['error'], "TEST_ERROR_MESSAGE")
+        self.assertEqual(result.errors[0]['request_id'], "test-request-id")
 
     def test_parse_insert_response_continue_on_error_false(self):
         mock_api_response = Mock()


### PR DESCRIPTION
**Why**

- For the "Continue on Error" functionality, request-IDs should be included in the response for all errors or partial failure cases.

**Goal**

- Ensure that request-IDs are consistently included in all error and partial failure responses when using "Continue on Error" .