### PR TITLE
SK-1906 Improve debugging in connections

### DIFF
--- a/skyflow/utils/_skyflow_messages.py
+++ b/skyflow/utils/_skyflow_messages.py
@@ -275,6 +275,7 @@ class SkyflowMessages:
         UPDATE_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Update request resulted in failure."
         QUERY_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Query request resulted in failure."
         GET_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Get request resulted in failure."
+        INVOKE_CONNECTION_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Invoke connection request resulted in failure."
 
     class Interface(Enum):
         INSERT = "INSERT"

--- a/skyflow/utils/_utils.py
+++ b/skyflow/utils/_utils.py
@@ -341,6 +341,11 @@ def parse_invoke_connection_response(api_response: requests.Response):
 
         if 'x-request-id' in api_response.headers:
             message += ' - request id: ' + api_response.headers['x-request-id']
+        
+        if 'error-from-client' in api_response.headers:
+            error_from_client = api_response.headers['error-from-client']
+            details = [{ "error_from_client": error_from_client }]
+            raise SkyflowError(message, status_code, details=details)
 
         raise SkyflowError(message, status_code)
 

--- a/skyflow/vault/controller/_connections.py
+++ b/skyflow/vault/controller/_connections.py
@@ -3,7 +3,7 @@ import requests
 from skyflow.error import SkyflowError
 from skyflow.utils import construct_invoke_connection_request, SkyflowMessages, get_metrics, \
     parse_invoke_connection_response
-from skyflow.utils.logger import log_info
+from skyflow.utils.logger import log_info, log_error_log
 from skyflow.vault.connection import InvokeConnectionRequest
 
 
@@ -36,6 +36,7 @@ class Connection:
             return invoke_connection_response
 
         except Exception as e:
+            log_error_log(SkyflowMessages.ErrorLogs.INVOKE_CONNECTION_REQUEST_REJECTED.value, self.__vault_client.get_logger())
             if isinstance(e, SkyflowError): raise e
             raise SkyflowError(SkyflowMessages.Error.INVOKE_CONNECTION_FAILED.value,
                                SkyflowMessages.ErrorCodes.SERVER_ERROR.value)

--- a/skyflow/vault/controller/_connections.py
+++ b/skyflow/vault/controller/_connections.py
@@ -27,7 +27,7 @@ class Connection:
 
         invoke_connection_request.headers['sky-metadata'] = json.dumps(get_metrics())
 
-        log_info(SkyflowMessages.Info.INVOKE_CONNECTION_TRIGGERED, self.__vault_client.get_logger())
+        log_info(SkyflowMessages.Info.INVOKE_CONNECTION_TRIGGERED.value, self.__vault_client.get_logger())
 
         try:
             response = session.send(invoke_connection_request)
@@ -36,5 +36,6 @@ class Connection:
             return invoke_connection_response
 
         except Exception as e:
+            if isinstance(e, SkyflowError): raise e
             raise SkyflowError(SkyflowMessages.Error.INVOKE_CONNECTION_FAILED.value,
                                SkyflowMessages.ErrorCodes.SERVER_ERROR.value)

--- a/tests/utils/test__utils.py
+++ b/tests/utils/test__utils.py
@@ -344,7 +344,8 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             parse_invoke_connection_response(mock_response)
 
-        self.assertEqual(context.exception.message, "Not Found - request id: 1234")
+        self.assertEqual(context.exception.message, "Not Found")
+        self.assertEqual(context.exception.request_id, "1234")
 
     @patch("requests.Response")
     def test_parse_invoke_connection_response_http_error_without_json_error_message(self, mock_response):
@@ -357,7 +358,7 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             parse_invoke_connection_response(mock_response)
 
-        self.assertEqual(context.exception.message, SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format("Internal Server Error") + " - request id: 1234")
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format("Internal Server Error"))
 
     @patch("skyflow.utils._utils.log_and_reject_error")
     def test_handle_exception_json_error(self, mock_log_and_reject_error):

--- a/tests/vault/controller/test__connection.py
+++ b/tests/vault/controller/test__connection.py
@@ -4,6 +4,7 @@ import requests
 from skyflow.error import SkyflowError
 from skyflow.utils import SkyflowMessages, parse_invoke_connection_response
 from skyflow.utils.enums import RequestMethod
+from skyflow.utils._version import SDK_VERSION
 from skyflow.vault.connection import InvokeConnectionRequest
 from skyflow.vault.controller import Connection
 
@@ -21,7 +22,8 @@ VALID_QUERY_PARAMS = {"query_key": "value"}
 INVALID_HEADERS = "invalid_headers"
 INVALID_BODY = "invalid_body"
 FAILURE_STATUS_CODE = 400
-ERROR_RESPONSE_CONTENT = b'{"error": {"message": "Invalid Request"}}'
+ERROR_RESPONSE_CONTENT = '"message": "Invalid Request"'
+ERROR_FROM_CLIENT_RESPONSE_CONTENT = b'{"error": {"message": "Invalid Request"}}'
 
 class TestConnection(unittest.TestCase):
     def setUp(self):
@@ -99,12 +101,14 @@ class TestConnection(unittest.TestCase):
 
         with self.assertRaises(SkyflowError) as context:
             self.connection.invoke(request)
-        self.assertEqual(context.exception.message, SkyflowMessages.Error.INVOKE_CONNECTION_FAILED.value)
+        self.assertEqual(context.exception.message, f'Skyflow Python SDK {SDK_VERSION} Response {ERROR_RESPONSE_CONTENT} is not valid JSON.')
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format(ERROR_RESPONSE_CONTENT))
+        self.assertEqual(context.exception.http_code, 400)
 
     def test_parse_invoke_connection_response_error_from_client(self):
         mock_response = Mock(spec=requests.Response)
         mock_response.status_code = FAILURE_STATUS_CODE
-        mock_response.content = ERROR_RESPONSE_CONTENT
+        mock_response.content = ERROR_FROM_CLIENT_RESPONSE_CONTENT
         mock_response.headers = {
             'error-from-client': 'true',
             'x-request-id': '12345'
@@ -117,4 +121,5 @@ class TestConnection(unittest.TestCase):
         exception = context.exception
 
         self.assertTrue(any(detail.get('error_from_client') == 'true' for detail in exception.details))
+        self.assertEqual(exception.request_id, '12345')
 

--- a/tests/vault/controller/test__connection.py
+++ b/tests/vault/controller/test__connection.py
@@ -1,8 +1,8 @@
 import unittest
 from unittest.mock import Mock, patch
-
+import requests
 from skyflow.error import SkyflowError
-from skyflow.utils import SkyflowMessages
+from skyflow.utils import SkyflowMessages, parse_invoke_connection_response
 from skyflow.utils.enums import RequestMethod
 from skyflow.vault.connection import InvokeConnectionRequest
 from skyflow.vault.controller import Connection
@@ -21,7 +21,7 @@ VALID_QUERY_PARAMS = {"query_key": "value"}
 INVALID_HEADERS = "invalid_headers"
 INVALID_BODY = "invalid_body"
 FAILURE_STATUS_CODE = 400
-ERROR_RESPONSE_CONTENT = '{"error": {"message": "error occurred"}}'
+ERROR_RESPONSE_CONTENT = b'{"error": {"message": "Invalid Request"}}'
 
 class TestConnection(unittest.TestCase):
     def setUp(self):
@@ -100,25 +100,21 @@ class TestConnection(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             self.connection.invoke(request)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.INVOKE_CONNECTION_FAILED.value)
-        self.assertTrue(context.exception.details['error_from_client'])
 
-    @patch('requests.Session.send')
-    def test_invoke_request_error_from_client(self, mock_send):
-        mock_response = Mock()
+    def test_parse_invoke_connection_response_error_from_client(self):
+        mock_response = Mock(spec=requests.Response)
         mock_response.status_code = FAILURE_STATUS_CODE
         mock_response.content = ERROR_RESPONSE_CONTENT
-        mock_response.headers = {'error-from-client': True}
-        mock_send.return_value = mock_response
-
-        request = InvokeConnectionRequest(
-            method=RequestMethod.POST,
-            body=VALID_BODY,
-            path_params=VALID_PATH_PARAMS,
-            headers=VALID_HEADERS,
-            query_params=VALID_QUERY_PARAMS
-        )
+        mock_response.headers = {
+            'error-from-client': 'true',
+            'x-request-id': '12345'
+        }
+        mock_response.raise_for_status.side_effect = requests.HTTPError()
 
         with self.assertRaises(SkyflowError) as context:
-            self.connection.invoke(request)
-        self.assertEqual(context.exception.message, SkyflowMessages.Error.INVOKE_CONNECTION_FAILED.value)
-        self.assertTrue(context.exception.details['error_from_client'])
+            parse_invoke_connection_response(mock_response)
+
+        exception = context.exception
+
+        self.assertTrue(any(detail.get('error_from_client') == 'true' for detail in exception.details))
+


### PR DESCRIPTION
This PR addresses feedback as well as customer request for invoke connections.

## Why
- When invoke connection request fails, the SDK throws an error with relevant details received from the API.
- However, the customer is unable to debug whether error occurred on their end or third-party end based on given info.

## Goal
- Customers should be easily able to debug whether an error occurred on their end or third-party end
- Improved error response structure to help customers with their problem

## Testing
- The changed were tested manually
- Added unit tests for the changes
