### PR TITLE
Release/25.3.1

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 if sys.version_info < (3, 8):
     raise RuntimeError("skyflow requires Python 3.8+")
-current_version = '2.0.0b1.dev0+dcb5ddc'
+current_version = '2.0.0b1.dev0+3d4ee51'
 
 setup(
     name='skyflow',

--- a/skyflow/utils/_skyflow_messages.py
+++ b/skyflow/utils/_skyflow_messages.py
@@ -277,6 +277,7 @@ class SkyflowMessages:
         UPDATE_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Update request resulted in failure."
         QUERY_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Query request resulted in failure."
         GET_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Get request resulted in failure."
+        INVOKE_CONNECTION_REQUEST_REJECTED = f"{ERROR}: [{error_prefix}] Invoke connection request resulted in failure."
 
     class Interface(Enum):
         INSERT = "INSERT"

--- a/skyflow/utils/_utils.py
+++ b/skyflow/utils/_utils.py
@@ -327,23 +327,29 @@ def parse_invoke_connection_response(api_response: requests.Response):
 
             invoke_connection_response.response = json_content
             return invoke_connection_response
-        except:
+        except Exception as e:
             raise SkyflowError(SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format(content), status_code)
     except HTTPError:
-        message = SkyflowMessages.Error.API_ERROR.value.format(status_code)
-        if api_response and api_response.content:
-            try:
-                error_response = json.loads(content)
-                if isinstance(error_response.get('error'), dict) and 'message' in error_response['error']:
-                    message = error_response['error']['message']
-            except json.JSONDecodeError:
-                message = SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format(content)
+        message = SkyflowMessages.Error.API_ERROR.value.format(status_code)  
+        try:
+            error_response = json.loads(content)                    
+            request_id = api_response.headers['x-request-id']
+            error_from_client = api_response.headers.get('error-from-client')
 
-        if 'x-request-id' in api_response.headers:
-            message += ' - request id: ' + api_response.headers['x-request-id']
+            status_code = error_response.get('error', {}).get('http_code', 500)  # Default to 500 if not found
+            http_status = error_response.get('error', {}).get('http_status')
+            grpc_code = error_response.get('error', {}).get('grpc_code')
+            details = error_response.get('error', {}).get('details')
+            message = error_response.get('error', {}).get('message', "An unknown error occurred.")
+            
+            if error_from_client is not None:
+                if details is None: details = []
+                details.append({'error_from_client': error_from_client})
 
+            raise SkyflowError(message, status_code, request_id, grpc_code, http_status, details)
+        except json.JSONDecodeError:
+            message = SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format(content)
         raise SkyflowError(message, status_code)
-
 
 def log_and_reject_error(description, status_code, request_id, http_status=None, grpc_code=None, details=None, logger = None):
     raise SkyflowError(description, status_code, request_id, grpc_code, http_status, details)

--- a/skyflow/utils/_version.py
+++ b/skyflow/utils/_version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = '2.0.0b1.dev0+dcb5ddc'
+SDK_VERSION = '2.0.0b1.dev0+3d4ee51'

--- a/skyflow/vault/controller/_connections.py
+++ b/skyflow/vault/controller/_connections.py
@@ -3,7 +3,7 @@ import requests
 from skyflow.error import SkyflowError
 from skyflow.utils import construct_invoke_connection_request, SkyflowMessages, get_metrics, \
     parse_invoke_connection_response
-from skyflow.utils.logger import log_info
+from skyflow.utils.logger import log_info, log_error_log
 from skyflow.vault.connection import InvokeConnectionRequest
 
 
@@ -27,7 +27,7 @@ class Connection:
 
         invoke_connection_request.headers['sky-metadata'] = json.dumps(get_metrics())
 
-        log_info(SkyflowMessages.Info.INVOKE_CONNECTION_TRIGGERED, self.__vault_client.get_logger())
+        log_info(SkyflowMessages.Info.INVOKE_CONNECTION_TRIGGERED.value, self.__vault_client.get_logger())
 
         try:
             response = session.send(invoke_connection_request)
@@ -36,5 +36,7 @@ class Connection:
             return invoke_connection_response
 
         except Exception as e:
+            log_error_log(SkyflowMessages.ErrorLogs.INVOKE_CONNECTION_REQUEST_REJECTED.value, self.__vault_client.get_logger())
+            if isinstance(e, SkyflowError): raise e
             raise SkyflowError(SkyflowMessages.Error.INVOKE_CONNECTION_FAILED.value,
                                SkyflowMessages.ErrorCodes.SERVER_ERROR.value)

--- a/tests/utils/test__utils.py
+++ b/tests/utils/test__utils.py
@@ -344,7 +344,8 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             parse_invoke_connection_response(mock_response)
 
-        self.assertEqual(context.exception.message, "Not Found - request id: 1234")
+        self.assertEqual(context.exception.message, "Not Found")
+        self.assertEqual(context.exception.request_id, "1234")
 
     @patch("requests.Response")
     def test_parse_invoke_connection_response_http_error_without_json_error_message(self, mock_response):
@@ -357,7 +358,7 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             parse_invoke_connection_response(mock_response)
 
-        self.assertEqual(context.exception.message, SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format("Internal Server Error") + " - request id: 1234")
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.RESPONSE_NOT_JSON.value.format("Internal Server Error"))
 
     @patch("skyflow.utils._utils.log_and_reject_error")
     def test_handle_exception_json_error(self, mock_log_and_reject_error):


### PR DESCRIPTION
## Why
- When invoke connection request fails, the SDK throws an error with relevant details received from the API.
- However, the customer is unable to debug whether error occurred on their end or third-party end based on given info.
## Goal
- Customers should be easily able to debug whether an error occurred on their end or third-party end
- Improved error response structure to help customers with their problem
