### PR TITLE
SK-2116 update masking method readme and sample

### DIFF
--- a/README.md
+++ b/README.md
@@ -1929,7 +1929,7 @@ try:
         # Image-specific options
         # output_processed_image=True,  # Include processed image
         # output_ocr_text=True,  # Include OCR text
-        # masking_method=MaskingMethod.BLACKOUT,  # Masking method
+        # masking_method=MaskingMethod.BLACKBOX,  # Masking method
 
         # PDF-specific options
         # pixel_density=1.5,  # PDF processing density

--- a/samples/detect_api/deidentify_file.py
+++ b/samples/detect_api/deidentify_file.py
@@ -65,7 +65,7 @@ def perform_file_deidentification():
             # Image-specific options
             output_processed_image=True,  # Include processed image in output
             output_ocr_text=True,  # Include OCR text in response
-            masking_method=MaskingMethod.BLACKOUT,  # Masking method for images
+            masking_method=MaskingMethod.BLACKBOX,  # Masking method for images
 
             # PDF-specific options
             pixel_density=15,  # Pixel density for PDF processing


### PR DESCRIPTION
Updated the readme.md & sample to support `BLACKBOX` instead of `BLACKOUT` as a masking method for `detect image`.

### Why:
- Masking method `BLACKOUT` is not supported by the `detect API`.
