### PR TITLE
SK-2296 Use sessions for insert method

### DIFF
--- a/.github/workflows/internal-release.yml
+++ b/.github/workflows/internal-release.yml
@@ -1,0 +1,22 @@
+name: Internal Release
+
+on:
+  push:
+    tags-ignore:
+      - '*.*'
+    paths-ignore:
+      - "setup.py"
+      - "*.yml"
+      - "*.md"
+      - "skyflow/version.py"
+      - "samples/**"
+    branches:
+      - release/*
+
+jobs:
+  build-and-deploy:
+    uses: ./.github/workflows/shared-build-and-deploy.yml
+    with:
+      ref: ${{ github.ref_name }}
+      tag: 'internal'
+    secrets: inherit

--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -1,0 +1,74 @@
+name: Shared Build and Deploy
+
+on:
+  workflow_call:
+    inputs:
+      ref:
+        description: 'Git reference to use (e.g., main or branch name)'
+        required: true
+        type: string
+
+      tag:
+        description: 'Release Tag'
+        required: true
+        type: string
+
+jobs:
+  build-and-deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v2
+      - name: Install dependencies
+        run: |
+          python -m pip install --upgrade pip
+          pip install setuptools wheel twine
+      - name: Resolve Branch for the Tagged Commit
+        id: resolve-branch
+        if: ${{ inputs.tag == 'beta' || inputs.tag == 'public' }} 
+        run: |
+          TAG_COMMIT=$(git rev-list -n 1 ${{ github.ref_name }})
+          BRANCH_NAME=$(git branch -r --contains $TAG_COMMIT | grep -o 'origin/.*' | sed 's|origin/||' | head -n 1)
+          if [ -z "$BRANCH_NAME" ]; then
+            echo "Error: Could not resolve branch for the tag."
+            exit 1
+          fi
+          echo "Resolved Branch Name: $BRANCH_NAME"
+          echo "branch_name=$BRANCH_NAME" >> $GITHUB_ENV
+      - name: Get Previous tag
+        id: previoustag
+        uses: WyriHaximus/github-action-get-previous-tag@v1
+        with:
+          fallback: 1.0.0
+
+      - name: Bump Version
+        run: |
+          chmod +x ./ci-scripts/bump_version.sh
+          if ${{ inputs.tag == 'internal' }}; then
+            ./ci-scripts/bump_version.sh "${{ steps.previoustag.outputs.tag }}" "$(git rev-parse --short "$GITHUB_SHA")"
+          else
+            ./ci-scripts/bump_version.sh "${{ steps.previoustag.outputs.tag }}"
+          fi
+      - name: Commit changes
+        run: |
+          git config user.name "${{ github.actor }}"
+          git config user.email "${{ github.actor }}@users.noreply.github.com"
+          git add setup.py
+          git add skyflow/version.py
+          if [[ "${{ inputs.tag }}" == "internal" ]]; then
+            VERSION="${{ steps.previoustag.outputs.tag }}.dev0+$(git rev-parse --short $GITHUB_SHA)"
+            COMMIT_MESSAGE="[AUTOMATED] Private Release $VERSION"
+            git commit -m "$COMMIT_MESSAGE"
+            git push origin ${{ github.ref_name }} -f
+          fi
+      - name: Build and Publish to JFrog Artifactory
+        if: ${{ inputs.tag == 'internal' }}
+        env:
+          TWINE_USERNAME: ${{ secrets.JFROG_USERNAME }}
+          TWINE_PASSWORD: ${{ secrets.JFROG_PASSWORD }}
+        run: |
+          python setup.py sdist bdist_wheel
+          twine upload --repository-url https://prekarilabs.jfrog.io/artifactory/api/pypi/skyflow-python/ dist/*

--- a/ci-scripts/bump_version.sh
+++ b/ci-scripts/bump_version.sh
@@ -1,22 +1,19 @@
 Version=$1
 SEMVER=$Version
-
 if [ -z $2 ]
 then
 	echo "Bumping package version to $1"
-
 	sed -E "s/current_version = .+/current_version = \'$SEMVER\'/g" setup.py > tempfile && cat tempfile > setup.py && rm -f tempfile
 	sed -E "s/SDK_VERSION = .+/SDK_VERSION = \'$SEMVER\'/g" skyflow/version.py > tempfile && cat tempfile > skyflow/version.py && rm -f tempfile
-
 	echo --------------------------
 	echo "Done, Package now at $1"
 
 else
-	echo "Bumping package version to $1-dev.$2"
+	echo "Bumping package version to $1.dev0+$2"
 
-	sed -E "s/current_version = .+/current_version = \'$SEMVER-dev.$2\'/g" setup.py > tempfile && cat tempfile > setup.py && rm -f tempfile
-	sed -E "s/SDK_VERSION = .+/SDK_VERSION = \'$SEMVER-dev.$2\'/g" skyflow/version.py > tempfile && cat tempfile > skyflow/version.py && rm -f tempfile
+	sed -E "s/current_version = .+/current_version = \'$SEMVER.dev0+$2\'/g" setup.py > tempfile && cat tempfile > setup.py && rm -f tempfile
+	sed -E "s/SDK_VERSION = .+/SDK_VERSION = \'$SEMVER.dev0+$2\'/g" skyflow/version.py > tempfile && cat tempfile > skyflow/version.py && rm -f tempfile
 
 	echo --------------------------
-	echo "Done, Package now at $1-dev.$2"
+	echo "Done, Package now at $1.dev0+$2"
 fi

--- a/skyflow/_utils.py
+++ b/skyflow/_utils.py
@@ -53,6 +53,7 @@ def log_error(message: str, interface: str):
 class InfoMessages(Enum):
     INITIALIZE_CLIENT = "Initializing skyflow client"
     CLIENT_INITIALIZED = "Initialized skyflow client successfully"
+    CLOSING_SESSION = "Closing the session"
     VALIDATE_INSERT_RECORDS = "Validating insert records"
     VALIDATE_DETOKENIZE_INPUT = "Validating detokenize input"
     VALIDATE_GET_BY_ID_INPUT = "Validating getByID input"

--- a/skyflow/errors/_skyflow_errors.py
+++ b/skyflow/errors/_skyflow_errors.py
@@ -16,6 +16,7 @@ class SkyflowErrorCodes(Enum):
 
 class SkyflowErrorMessages(Enum):
     API_ERROR = "Server returned status code %s"
+    NETWORK_ERROR = "Network error occurred: %s"
 
     FILE_NOT_FOUND = "File at %s not found"
     FILE_INVALID_JSON = "File at %s is not in JSON format"

--- a/skyflow/vault/_client.py
+++ b/skyflow/vault/_client.py
@@ -5,6 +5,7 @@ import json
 import types
 import requests
 import asyncio
+from requests.adapters import HTTPAdapter
 from skyflow.vault._insert import getInsertRequestBody, processResponse, convertResponse
 from skyflow.vault._update import sendUpdateRequests, createUpdateResponseBody
 from skyflow.vault._config import Configuration, ConnectionConfig, DeleteOptions, DetokenizeOptions, GetOptions, InsertOptions, UpdateOptions, QueryOptions
@@ -36,49 +37,71 @@ class Client:
             raise SkyflowError(SkyflowErrorCodes.INVALID_INPUT, SkyflowErrorMessages.TOKEN_PROVIDER_ERROR.value % (
                 str(type(config.tokenProvider))), interface=interface)
 
+        self._create_session()
         self.vaultID = config.vaultID
         self.vaultURL = config.vaultURL.rstrip('/')
         self.tokenProvider = config.tokenProvider
         self.storedToken = ''
         log_info(InfoMessages.CLIENT_INITIALIZED.value, interface=interface)
+        
+    def _create_session(self):
+        self.session = requests.Session()
+        adapter = HTTPAdapter(pool_connections=1, pool_maxsize=25, pool_block=True)
+        self.session.mount("https://", adapter)
+
+    def __del__(self):
+        if (self.session is not None):
+            log_info(InfoMessages.CLOSING_SESSION.value, interface=InterfaceName.CLIENT.value)
+            self.session.close()
+            self.session = None
+            
+    def _get_session(self):
+        if (self.session is None):
+            self._create_session()
+        return self.session
 
     def insert(self, records: dict, options: InsertOptions = InsertOptions()):
+        max_retries = 1
         interface = InterfaceName.INSERT.value
         log_info(InfoMessages.INSERT_TRIGGERED.value, interface=interface)
         self._checkConfig(interface)
-
         jsonBody = getInsertRequestBody(records, options)
         requestURL = self._get_complete_vault_url()
-        self.storedToken = tokenProviderWrapper(
-            self.storedToken, self.tokenProvider, interface)
-        headers = {
-            "Authorization": "Bearer " + self.storedToken,
-            "sky-metadata": json.dumps(getMetrics())
-        }
-        max_retries = 3
-        # Use for-loop for retry logic, avoid code repetition
-        for attempt in range(max_retries+1):
+
+        for attempt in range(max_retries + 1):
             try:
-                # If jsonBody is a dict, use json=, else use data=
-                response = requests.post(requestURL, data=jsonBody, headers=headers)
+                self.storedToken = tokenProviderWrapper(
+                    self.storedToken, self.tokenProvider, interface)
+                headers = {
+                    "Authorization": "Bearer " + self.storedToken,
+                    "sky-metadata": json.dumps(getMetrics()),
+                }
+                response = self._get_session().post(
+                    requestURL,
+                    data=jsonBody,
+                    headers=headers,
+                )
                 processedResponse = processResponse(response)
                 result, partial = convertResponse(records, processedResponse, options)
                 if partial:
                     log_error(SkyflowErrorMessages.BATCH_INSERT_PARTIAL_SUCCESS.value, interface)
-                    raise SkyflowError(SkyflowErrorCodes.PARTIAL_SUCCESS, SkyflowErrorMessages.BATCH_INSERT_PARTIAL_SUCCESS.value, result, interface=interface)
-                if 'records' not in result:
+                elif 'records' not in result:
                     log_error(SkyflowErrorMessages.BATCH_INSERT_FAILURE.value, interface)
-                    raise SkyflowError(SkyflowErrorCodes.SERVER_ERROR, SkyflowErrorMessages.BATCH_INSERT_FAILURE.value, result, interface=interface)
-                log_info(InfoMessages.INSERT_DATA_SUCCESS.value, interface)
-                return result
-            except Exception as err:
-                if attempt < max_retries:
-                    continue
                 else:
-                    if isinstance(err, SkyflowError):
-                        raise err
-                    else:
-                        raise SkyflowError(SkyflowErrorCodes.SERVER_ERROR, f"Error occurred: {err}", interface=interface)
+                    log_info(InfoMessages.INSERT_DATA_SUCCESS.value, interface)
+                return result
+            except requests.exceptions.ConnectionError as err:
+                if attempt < max_retries:
+                    continue                
+                raise SkyflowError(
+                    SkyflowErrorCodes.SERVER_ERROR, 
+                    SkyflowErrorMessages.NETWORK_ERROR.value % str(err),
+                    interface=interface
+                )
+            except SkyflowError as err:
+                if  err.code != SkyflowErrorCodes.SERVER_ERROR or attempt >= max_retries:
+                    raise err
+                continue
 
     def detokenize(self, records: dict, options: DetokenizeOptions = DetokenizeOptions()):
         interface = InterfaceName.DETOKENIZE.value


### PR DESCRIPTION
This PR modifies `insert` method to utilise `sessions` provided by `requests` library.

## Why
- On larger scale, the simple `requests.post` leads to choking and connection errors.
- therefore, we needed to optimise connection pooling by using `sessions` instead.
- We also needed to add retries for any connection related and 500 errors.

## Goal
- Optimised connection pooling by utilising `sessions`
- Retry any connection related and/or 500 errors.

## Testing
- Tested the changes manually
- Load tested the changes for 2M records using locust.