### PR TITLE
SK-2851: Loosen PyJWT, python-dotenv, urllib3 dependency pins

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,12 +1,12 @@
 python_dateutil >= 2.5.3
 setuptools >= 21.0.0
-urllib3 >= 1.25.3, < 2.1.0
+urllib3 >= 1.25.3, < 3
 pydantic >= 2
 typing-extensions >= 4.7.1
 DateTime~=5.5
-PyJWT~=2.9.0
+PyJWT >= 2.9, < 3
 requests~=2.32.3
 coverage
 cryptography
-python-dotenv~=1.0.1
+python-dotenv >= 1.0, < 2
 httpx

--- a/setup.py
+++ b/setup.py
@@ -26,15 +26,15 @@ setup(
     install_requires=[
         'python_dateutil >= 2.5.3',
     	'setuptools >= 75.3.3',
-        'urllib3 >= 1.25.3, <= 2.6.3',
+        'urllib3 >= 1.25.3, < 3',
         'pydantic >= 2',
         'typing-extensions >= 4.7.1',
         'DateTime~=5.5',
-        'PyJWT~=2.9.0',
+        'PyJWT >= 2.9, < 3',
         'requests~=2.32.3',
         'coverage',
         'cryptography',
-        'python-dotenv~=1.0.1',
+        'python-dotenv >= 1.0, < 2',
         'httpx'
     ],
     extras_require={


### PR DESCRIPTION
## Summary

Widens three transitive dependency pins that were unnecessarily tight, blocking customers from picking up upstream security fixes (notably [CVE-2026-32597](https://github.com/advisories/GHSA-752w-5fwx-jx9f) in PyJWT < 2.12.0). Reported via [SK-2851](https://skyflow.atlassian.net/browse/SK-2851) by a customer hitting all three conflicts at once.

| Dep | Before | After | Why |
|---|---|---|---|
| PyJWT | `~=2.9.0` (2.9.x only) | `>= 2.9, < 3` | Allow 2.12+ so customers can resolve CVE-2026-32597 in their own code. The SDK only signs JWTs and isn't itself exposed to the CVE, so the floor stays at 2.9. |
| python-dotenv | `~=1.0.1` (1.0.x only) | `>= 1.0, < 2` | Latest is 1.2.2. The SDK uses `load_dotenv()`/`find_dotenv()`, stable since 1.0. |
| urllib3 | `>= 1.25.3, < 2.1.0` (req.txt) / `<= 2.6.3` (setup.py) | `>= 1.25.3, < 3` | Opens the full 2.x line (latest 2.7.0). Also harmonizes the two files, which had drifted. |

No PyJWT 3 / python-dotenv 2 / urllib3 3 exist yet, so the `<major+1` caps don't restrict anything reachable today and protect us from a future breaking major.

## Test plan
- [x] `pip install -e .` resolves cleanly in a fresh venv (picks PyJWT 2.13.0, python-dotenv 1.2.2, urllib3 2.7.0)
- [x] Full test suite passes against the new latest versions (437 tests, 8 subtests)
- [x] CI green on this PR

https://claude.ai/code/session_01KSRSfYXWLyJHWjTAKmAXNo

---
_Generated by [Claude Code](https://claude.ai/code/session_01KSRSfYXWLyJHWjTAKmAXNo)_

[SK-2851]: https://skyflow.atlassian.net/browse/SK-2851?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ