### PR TITLE
[AUTOMATED] add NOT_FOUND 404 to HttpStatusCode constants

### DIFF
--- a/skyflow/utils/constants.py
+++ b/skyflow/utils/constants.py
@@ -21,6 +21,7 @@ class HttpStatusCode:
     OK = 200
     BAD_REQUEST = 400
     UNAUTHORIZED = 401
+    NOT_FOUND = 404
     INTERNAL_SERVER_ERROR = 500
 
 


### PR DESCRIPTION
## Summary
- Adds `NOT_FOUND = 404` to the `HttpStatusCode` constants class in `skyflow/utils/constants.py`
- Dummy PR to verify unit tests run correctly on pull request CI

## Test plan
- [ ] CI `test` job triggers on PR open
- [ ] All 615 unit tests pass
- [ ] Spell check (`codespell`) passes
- [ ] Linter (`ruff`) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)