### PR TITLE
SK-2986 use PAT for release version-bump push to bypass branch protection

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -20,6 +20,11 @@ jobs:
       - uses: actions/checkout@v2
         with:
           fetch-depth: 0
+          # Persist an admin credential so the automated version-bump push
+          # below satisfies the branch-protection ruleset's repo-admin bypass;
+          # the default GITHUB_TOKEN (github-actions[bot]) is not a bypass
+          # actor and would be rejected once PR enforcement is active. SK-2986.
+          token: ${{ secrets.PAT_ACTIONS }}
 
       - uses: actions/setup-python@v2
       - name: Install dependencies


### PR DESCRIPTION
## Why
Branch-protection rulesets now cover `main` (force-push/deletion active; PR + build-check staged). The automated release **version-bump commit is pushed directly to `main` as `github-actions[bot]`**, which is not a ruleset bypass actor — so once PR enforcement is activated the push would be rejected and releases would break.

## What
Point the release `actions/checkout` at `PAT_ACTIONS` (a repo-admin credential). `checkout` persists it and the later bump push reuses it, satisfying the ruleset **Repository Admin** bypass.

## ⚠️ Verify before activating PR enforcement
Confirm this repo's `PAT_ACTIONS` is owned by a **repo admin** with **Contents: write** (it is a per-repo secret). If not, point `token:` at a write-capable admin PAT/App. Alternative discussed in the java rollout: drop the version-bump push entirely so no bypass is needed.

Part of the SDK branch-protection rollout. Ref: SK-2986

🤖 Generated with [Claude Code](https://claude.com/claude-code)