### PR TITLE
SK-3039:Fix Skyflow clients bearertokens roles & context.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 if sys.version_info < (3, 9):
     raise RuntimeError("skyflow requires Python 3.9+")
-current_version = '2.1.2'
+current_version = '2.1.2.dev0+aee1bb9'
 
 with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()

--- a/setup.py
+++ b/setup.py
@@ -7,7 +7,7 @@ import sys
 
 if sys.version_info < (3, 9):
     raise RuntimeError("skyflow requires Python 3.9+")
-current_version = '2.1.2.dev0+aee1bb9'
+current_version = '2.1.2.dev0+5e4b2fb'
 
 with open('README.md', 'r', encoding='utf-8') as f:
     long_description = f.read()

--- a/skyflow/utils/_skyflow_messages.py
+++ b/skyflow/utils/_skyflow_messages.py
@@ -109,6 +109,7 @@ class SkyflowMessages:
         EMPTY_RECORD_IDS_IN_DELETE = f"{error_prefix} Validation error. 'record ids' array can't be empty. Specify one or more record ids."
         BULK_DELETE_FAILURE = f"{error_prefix} Delete operation failed."
         EMPTY_SKYFLOW_ID= f"{error_prefix} Validation error. skyflow_id can't be empty."
+        INVALID_SKYFLOW_ID_TYPE = f"{error_prefix} Validation error. 'skyflow_id' has a value of type {{}}. Specify 'skyflow_id' as a string."
         INVALID_FILE_COLUMN_NAME= f"{error_prefix} Validation error. 'column_name' can't be empty."
 
         INVALID_QUERY_TYPE = f"{error_prefix} Validation error. Query parameter is of type {{}}. Specify as a string."

--- a/skyflow/utils/_skyflow_messages.py
+++ b/skyflow/utils/_skyflow_messages.py
@@ -58,6 +58,8 @@ class SkyflowMessages:
         INVALID_ROLES_KEY_TYPE = f"{error_prefix} Validation error. Invalid roles. Specify roles as an array."
         EMPTY_ROLES_IN_CONFIG = f"{error_prefix} Validation error. Invalid roles for {{}} with id {{}}. Specify at least one role."
         EMPTY_ROLES = f"{error_prefix} Validation error. Invalid roles. Specify at least one role."
+        INVALID_ROLE_ELEMENT_TYPE_IN_CONFIG = f"{error_prefix} Validation error. Invalid roles for {{}} with id {{}}. Each role must be a non-empty string."
+        INVALID_ROLE_ELEMENT_TYPE = f"{error_prefix} Validation error. Invalid roles. Each role must be a non-empty string."
         EMPTY_CONTEXT_IN_CONFIG = f"{error_prefix} Initialization failed. Invalid context provided for {{}} with id {{}}. Specify context as type Context."
         EMPTY_CONTEXT = f"{error_prefix} Initialization failed. Invalid context provided. Specify context as type Context."
         INVALID_CONTEXT_IN_CONFIG = f"{error_prefix} Initialization failed. Invalid context for {{}} with id {{}}. Specify a valid context."

--- a/skyflow/utils/_version.py
+++ b/skyflow/utils/_version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = '2.1.2'
+SDK_VERSION = '2.1.2.dev0+aee1bb9'

--- a/skyflow/utils/_version.py
+++ b/skyflow/utils/_version.py
@@ -1,1 +1,1 @@
-SDK_VERSION = '2.1.2.dev0+aee1bb9'
+SDK_VERSION = '2.1.2.dev0+5e4b2fb'

--- a/skyflow/utils/validations/__init__.py
+++ b/skyflow/utils/validations/__init__.py
@@ -5,6 +5,7 @@ from ._validations import (
     validate_update_vault_config,
     validate_update_connection_config,
     validate_credentials,
+    validate_token_options,
     validate_log_level,
     validate_delete_request,
     validate_query_request,

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -2,6 +2,7 @@ import base64
 import json
 import os
 from skyflow.service_account import is_expired
+from skyflow.service_account._utils import _validate_and_resolve_ctx
 from skyflow.utils.enums import LogLevel, Env, RedactionType, TokenMode, DetectEntities, DetectOutputTranscriptions, \
     MaskingMethod
 from skyflow.error import SkyflowError
@@ -104,20 +105,35 @@ def validate_credentials(logger, credentials, config_id_type=None, config_id=Non
     if CredentialField.ROLES in credentials:
         validate_required_field(
             logger, credentials, CredentialField.ROLES, list,
-            SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE.value,
             SkyflowMessages.Error.EMPTY_ROLES_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_ROLES.value
+            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_ROLES.value,
+            SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE_IN_CONFIG.value.format(config_id_type, config_id)
+            if config_id_type and config_id else SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE.value
         )
+        if not credentials.get(CredentialField.ROLES):
+            raise SkyflowError(
+                SkyflowMessages.Error.EMPTY_ROLES_IN_CONFIG.value.format(config_id_type, config_id)
+                if config_id_type and config_id else SkyflowMessages.Error.EMPTY_ROLES.value,
+                invalid_input_error_code
+            )
 
     if CredentialField.CONTEXT in credentials:
-        validate_required_field(
-            logger, credentials, CredentialField.CONTEXT, str,
+        empty_context_error = (
             SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_CONTEXT.value,
+            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_CONTEXT.value
+        )
+        validate_required_field(
+            logger, credentials, CredentialField.CONTEXT, (str, dict),
+            empty_context_error,
             SkyflowMessages.Error.INVALID_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
             if config_id_type and config_id else SkyflowMessages.Error.INVALID_CONTEXT.value
         )
+        context = credentials.get(CredentialField.CONTEXT)
+        if isinstance(context, dict):
+            if not context:
+                raise SkyflowError(empty_context_error, invalid_input_error_code)
+            # Surface invalid ctx keys at config time instead of on the first API call.
+            _validate_and_resolve_ctx(context)
 
     if CredentialField.CREDENTIALS_STRING in credentials:
         validate_required_field(

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -102,6 +102,14 @@ def validate_token_options(logger, credentials, config_id_type=None, config_id=N
         if not credentials.get(CredentialField.ROLES):
             raise SkyflowError(empty_roles_error, invalid_input_error_code)
 
+        invalid_role_element_error = (
+            SkyflowMessages.Error.INVALID_ROLE_ELEMENT_TYPE_IN_CONFIG.value.format(config_id_type, config_id)
+            if config_id_type and config_id else SkyflowMessages.Error.INVALID_ROLE_ELEMENT_TYPE.value
+        )
+        for role in credentials.get(CredentialField.ROLES):
+            if not isinstance(role, str) or not role.strip():
+                raise SkyflowError(invalid_role_element_error, invalid_input_error_code)
+
     if CredentialField.CONTEXT in credentials:
         empty_context_error = (
             SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
@@ -310,7 +318,7 @@ def validate_update_connection_config(logger, config):
 
     if ConfigField.CREDENTIALS not in config:
         raise SkyflowError(SkyflowMessages.Error.EMPTY_CREDENTIALS.value.format(ConfigType.CONNECTION, connection_id), invalid_input_error_code)
-    validate_credentials(logger, config.get(ConfigField.CREDENTIALS))
+    validate_credentials(logger, config.get(ConfigField.CREDENTIALS), ConfigType.CONNECTION, connection_id)
 
     return True
 
@@ -519,6 +527,11 @@ def validate_insert_request(logger, request):
         raise SkyflowError(SkyflowMessages.Error.INVALID_CONTINUE_ON_ERROR_TYPE.value, invalid_input_error_code)
 
     if request.tokens:
+        if not isinstance(request.tokens, list) or not request.tokens or not all(
+                isinstance(t, dict) for t in request.tokens):
+            log_error_log(SkyflowMessages.ErrorLogs.EMPTY_TOKENS.value.format(RequestOperation.INSERT), logger=logger)
+            raise SkyflowError(SkyflowMessages.Error.INVALID_TYPE_OF_DATA_IN_INSERT.value, invalid_input_error_code)
+
         for i, item in enumerate(request.tokens, start=1):
             for key, value in item.items():
                 if key is None or key == "":
@@ -528,10 +541,6 @@ def validate_insert_request(logger, request):
                 if value is None or value == "":
                     log_error_log(SkyflowMessages.ErrorLogs.EMPTY_OR_NULL_KEY_IN_TOKENS.value.format(RequestOperation.INSERT, key),
                                   logger=logger)
-        if not isinstance(request.tokens, list) or not request.tokens or not all(
-                isinstance(t, dict) for t in request.tokens):
-            log_error_log(SkyflowMessages.ErrorLogs.EMPTY_TOKENS.value.format(RequestOperation.INSERT), logger=logger)
-            raise SkyflowError(SkyflowMessages.Error.INVALID_TYPE_OF_DATA_IN_INSERT.value, invalid_input_error_code)
 
     if request.token_mode == TokenMode.ENABLE and not request.tokens:
         raise SkyflowError(SkyflowMessages.Error.NO_TOKENS_IN_INSERT.value.format(request.token_mode), invalid_input_error_code)
@@ -737,7 +746,7 @@ def validate_detokenize_request(logger, request):
         raise SkyflowError(SkyflowMessages.Error.EMPTY_TOKENS_LIST_VALUE.value, invalid_input_error_code)
 
     for item in request.data:
-        if ResponseField.TOKEN not in item:
+        if not isinstance(item, dict) or ResponseField.TOKEN not in item:
             raise SkyflowError(SkyflowMessages.Error.INVALID_TOKENS_LIST_VALUE.value.format(type(request.data)),
                                invalid_input_error_code)
 

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -115,8 +115,10 @@ def validate_token_options(logger, credentials, config_id_type=None, config_id=N
             SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
             if config_id_type and config_id else SkyflowMessages.Error.EMPTY_CONTEXT.value
         )
+        # Scalars are accepted because the token engine and the auth service both support
+        # them as ctx claims - bool is listed explicitly even though it is an int subclass.
         validate_required_field(
-            logger, credentials, CredentialField.CONTEXT, (str, dict),
+            logger, credentials, CredentialField.CONTEXT, (str, dict, bool, int, float),
             empty_context_error,
             SkyflowMessages.Error.INVALID_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
             if config_id_type and config_id else SkyflowMessages.Error.INVALID_CONTEXT.value

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -82,6 +82,44 @@ def validate_api_key(api_key: str, logger = None) -> bool:
 
     return True
 
+def validate_token_options(logger, credentials, config_id_type=None, config_id=None):
+    """Validate the roles/context token options nested under credentials.
+
+    Shared by config validation and VaultClient, so a directly constructed client
+    cannot silently generate an unscoped or context-less token.
+    """
+    if CredentialField.ROLES in credentials:
+        empty_roles_error = (
+            SkyflowMessages.Error.EMPTY_ROLES_IN_CONFIG.value.format(config_id_type, config_id)
+            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_ROLES.value
+        )
+        validate_required_field(
+            logger, credentials, CredentialField.ROLES, list,
+            empty_roles_error,
+            SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE_IN_CONFIG.value.format(config_id_type, config_id)
+            if config_id_type and config_id else SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE.value
+        )
+        if not credentials.get(CredentialField.ROLES):
+            raise SkyflowError(empty_roles_error, invalid_input_error_code)
+
+    if CredentialField.CONTEXT in credentials:
+        empty_context_error = (
+            SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
+            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_CONTEXT.value
+        )
+        validate_required_field(
+            logger, credentials, CredentialField.CONTEXT, (str, dict),
+            empty_context_error,
+            SkyflowMessages.Error.INVALID_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
+            if config_id_type and config_id else SkyflowMessages.Error.INVALID_CONTEXT.value
+        )
+        context = credentials.get(CredentialField.CONTEXT)
+        if isinstance(context, dict):
+            if not context:
+                raise SkyflowError(empty_context_error, invalid_input_error_code)
+            # Surface invalid ctx keys at config time instead of on the first API call.
+            _validate_and_resolve_ctx(context)
+
 def validate_credentials(logger, credentials, config_id_type=None, config_id=None):
     key_present = [k for k in [CredentialField.PATH, CredentialField.TOKEN, CredentialField.CREDENTIALS_STRING, CredentialField.API_KEY] if credentials.get(k)]
 
@@ -102,38 +140,7 @@ def validate_credentials(logger, credentials, config_id_type=None, config_id=Non
         log_error_log(error_message, logger)
         raise SkyflowError(error_message, invalid_input_error_code)
 
-    if CredentialField.ROLES in credentials:
-        validate_required_field(
-            logger, credentials, CredentialField.ROLES, list,
-            SkyflowMessages.Error.EMPTY_ROLES_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_ROLES.value,
-            SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE.value
-        )
-        if not credentials.get(CredentialField.ROLES):
-            raise SkyflowError(
-                SkyflowMessages.Error.EMPTY_ROLES_IN_CONFIG.value.format(config_id_type, config_id)
-                if config_id_type and config_id else SkyflowMessages.Error.EMPTY_ROLES.value,
-                invalid_input_error_code
-            )
-
-    if CredentialField.CONTEXT in credentials:
-        empty_context_error = (
-            SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.EMPTY_CONTEXT.value
-        )
-        validate_required_field(
-            logger, credentials, CredentialField.CONTEXT, (str, dict),
-            empty_context_error,
-            SkyflowMessages.Error.INVALID_CONTEXT_IN_CONFIG.value.format(config_id_type, config_id)
-            if config_id_type and config_id else SkyflowMessages.Error.INVALID_CONTEXT.value
-        )
-        context = credentials.get(CredentialField.CONTEXT)
-        if isinstance(context, dict):
-            if not context:
-                raise SkyflowError(empty_context_error, invalid_input_error_code)
-            # Surface invalid ctx keys at config time instead of on the first API call.
-            _validate_and_resolve_ctx(context)
+    validate_token_options(logger, credentials, config_id_type, config_id)
 
     if CredentialField.CREDENTIALS_STRING in credentials:
         validate_required_field(

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -677,6 +677,8 @@ def validate_update_request(logger, request):
     skyflow_id = request.data.get(ResponseField.SKYFLOW_ID)
     if skyflow_id is None:
         log_error_log(SkyflowMessages.ErrorLogs.SKYFLOW_ID_IS_REQUIRED.value.format(RequestOperation.UPDATE), logger=logger)
+    elif not isinstance(skyflow_id, str):
+        raise SkyflowError(SkyflowMessages.Error.INVALID_SKYFLOW_ID_TYPE.value.format(type(skyflow_id)), invalid_input_error_code)
     elif not skyflow_id.strip():
         log_error_log(SkyflowMessages.ErrorLogs.EMPTY_SKYFLOW_ID.value.format(RequestOperation.UPDATE), logger=logger)
 
@@ -793,11 +795,16 @@ def validate_file_upload_request(logger, request):
     table = getattr(request, FileUploadField.TABLE, None)
     if table is None:
         raise SkyflowError(SkyflowMessages.Error.INVALID_TABLE_VALUE.value, invalid_input_error_code)
+    elif not isinstance(table, str):
+        log_error_log(SkyflowMessages.ErrorLogs.TABLE_IS_REQUIRED.value.format(RequestOperation.FILE_UPLOAD), logger=logger)
+        raise SkyflowError(SkyflowMessages.Error.INVALID_TABLE_VALUE.value, invalid_input_error_code)
     elif table.strip() == "":
         raise SkyflowError(SkyflowMessages.Error.EMPTY_TABLE_VALUE.value, invalid_input_error_code)
 
     # Skyflow ID
     skyflow_id = getattr(request, FileUploadField.SKYFLOW_ID, None)
+    if skyflow_id is not None and not isinstance(skyflow_id, str):
+        raise SkyflowError(SkyflowMessages.Error.INVALID_SKYFLOW_ID_TYPE.value.format(type(skyflow_id)), invalid_input_error_code)
     if skyflow_id is not None and skyflow_id.strip() == "":
         raise SkyflowError(SkyflowMessages.Error.EMPTY_SKYFLOW_ID.value.format(RequestOperation.FILE_UPLOAD), invalid_input_error_code)
 
@@ -805,6 +812,9 @@ def validate_file_upload_request(logger, request):
     column_name = getattr(request, FileUploadField.COLUMN_NAME, None)
     if column_name is None:
         raise SkyflowError(SkyflowMessages.Error.INVALID_FILE_COLUMN_NAME.value.format(type(column_name)), invalid_input_error_code)
+    elif not isinstance(column_name, str):
+        log_error_log(SkyflowMessages.ErrorLogs.EMPTY_FILE_COLUMN_NAME.value, logger)
+        raise SkyflowError(SkyflowMessages.Error.INVALID_COLUMN_NAME.value.format(type(column_name)), invalid_input_error_code)
     elif column_name.strip() == "":
         log_error_log(SkyflowMessages.ErrorLogs.EMPTY_FILE_COLUMN_NAME.value, logger)
         raise SkyflowError(SkyflowMessages.Error.INVALID_FILE_COLUMN_NAME.value.format(type(column_name)), invalid_input_error_code)
@@ -823,7 +833,7 @@ def validate_file_upload_request(logger, request):
 
     # Check base64 if present
     if not is_none_or_empty(base64_str):
-        if is_none_or_empty(file_name):
+        if not isinstance(file_name, str) or is_none_or_empty(file_name):
             raise SkyflowError(SkyflowMessages.Error.INVALID_FILE_NAME.value, invalid_input_error_code)
         try:
             base64.b64decode(base64_str)

--- a/skyflow/utils/validations/_validations.py
+++ b/skyflow/utils/validations/_validations.py
@@ -561,6 +561,10 @@ def validate_delete_request(logger, request):
         log_error_log(SkyflowMessages.ErrorLogs.EMPTY_IDS.value.format(RequestOperation.DELETE), logger=logger)
         raise SkyflowError(SkyflowMessages.Error.EMPTY_RECORD_IDS_IN_DELETE.value, invalid_input_error_code)
 
+    if not isinstance(request.ids, list):
+        log_error_log(SkyflowMessages.ErrorLogs.EMPTY_IDS.value.format(RequestOperation.DELETE), logger=logger)
+        raise SkyflowError(SkyflowMessages.Error.INVALID_IDS_TYPE.value.format(type(request.ids)), invalid_input_error_code)
+
 def validate_query_request(logger, request):
     if not isinstance(request.query, str):
         query_type = str(type(request.query))

--- a/skyflow/vault/client/client.py
+++ b/skyflow/vault/client/client.py
@@ -74,10 +74,15 @@ class VaultClient:
         elif CredentialField.TOKEN in credentials:
             return credentials.get(CredentialField.TOKEN)
 
-        options = {
-            OptionField.ROLE_IDS: self.__config.get(OptionField.ROLES),
-            OptionField.CTX: self.__config.get(OptionField.CTX)
-        }
+        options = {}
+        roles = credentials.get(CredentialField.ROLES)
+        if roles:
+            options[OptionField.ROLE_IDS] = roles
+
+        context = credentials.get(CredentialField.CONTEXT)
+        if context is not None:
+            options[OptionField.CTX] = context
+
         if CredentialField.TOKEN_URI_OPTION in credentials and credentials.get(CredentialField.TOKEN_URI_OPTION):
             options[CredentialField.TOKEN_URI_OPTION] = credentials.get(CredentialField.TOKEN_URI_OPTION)
 

--- a/skyflow/vault/client/client.py
+++ b/skyflow/vault/client/client.py
@@ -4,6 +4,7 @@ from skyflow.service_account import generate_bearer_token, generate_bearer_token
 from skyflow.utils import get_vault_url, get_credentials, SkyflowMessages
 from skyflow.utils.logger import log_info
 from skyflow.utils.constants import OptionField, CredentialField, ConfigField
+from skyflow.utils.validations import validate_token_options
 
 
 class VaultClient:
@@ -74,14 +75,14 @@ class VaultClient:
         elif CredentialField.TOKEN in credentials:
             return credentials.get(CredentialField.TOKEN)
 
-        options = {}
-        roles = credentials.get(CredentialField.ROLES)
-        if roles:
-            options[OptionField.ROLE_IDS] = roles
+        validate_token_options(self.__logger, credentials)
 
-        context = credentials.get(CredentialField.CONTEXT)
-        if context is not None:
-            options[OptionField.CTX] = context
+        options = {}
+        if CredentialField.ROLES in credentials:
+            options[OptionField.ROLE_IDS] = credentials.get(CredentialField.ROLES)
+
+        if CredentialField.CONTEXT in credentials:
+            options[OptionField.CTX] = credentials.get(CredentialField.CONTEXT)
 
         if CredentialField.TOKEN_URI_OPTION in credentials and credentials.get(CredentialField.TOKEN_URI_OPTION):
             options[CredentialField.TOKEN_URI_OPTION] = credentials.get(CredentialField.TOKEN_URI_OPTION)

--- a/tests/client/test_skyflow.py
+++ b/tests/client/test_skyflow.py
@@ -420,6 +420,55 @@ class TestVaultClient(unittest.TestCase):
         self.assertEqual(options_passed["token_uri"], "https://custom-token-uri.com/token")
 
 
+class TestBearerTokenContextAndRolesEndToEnd(unittest.TestCase):
+    """roles/context configured via add_vault_config() must reach the token engine."""
+
+    CREDENTIALS_STRING = '{"clientID":"id","privateKey":"pk","keyID":"kid","tokenURI":"https://token.uri"}'
+
+    def _build_and_generate(self, credentials, mock_gen):
+        config = {
+            "vault_id": "VAULT_ID",
+            "cluster_id": "CLUSTER_ID",
+            "env": Env.DEV,
+            "credentials": credentials,
+        }
+        client = (
+            Skyflow.builder()
+            .add_vault_config(config)
+            .set_log_level(LogLevel.OFF)
+            .build()
+        )
+        vault_client = client._Skyflow__builder.get_vault_config("VAULT_ID").get("vault_client")
+        vault_client.initialize_client_configuration()
+        return mock_gen.call_args[0][1]
+
+    @patch("skyflow.vault.client.client.Skyflow")
+    @patch("skyflow.vault.client.client.generate_bearer_token_from_creds", return_value=("token", "bearer"))
+    def test_string_context_and_roles_reach_token_engine(self, mock_gen, _mock_api):
+        options = self._build_and_generate(
+            {
+                "credentials_string": self.CREDENTIALS_STRING,
+                "roles": ["role_id_1", "role_id_2"],
+                "context": "user_12345",
+            },
+            mock_gen,
+        )
+        self.assertEqual(options["role_ids"], ["role_id_1", "role_id_2"])
+        self.assertEqual(options["ctx"], "user_12345")
+
+    @patch("skyflow.vault.client.client.Skyflow")
+    @patch("skyflow.vault.client.client.generate_bearer_token_from_creds", return_value=("token", "bearer"))
+    def test_dict_context_reaches_token_engine(self, mock_gen, _mock_api):
+        options = self._build_and_generate(
+            {
+                "credentials_string": self.CREDENTIALS_STRING,
+                "context": {"role": "admin", "department": "finance"},
+            },
+            mock_gen,
+        )
+        self.assertEqual(options["ctx"], {"role": "admin", "department": "finance"})
+
+
 class TestUpdateLogLevelDeprecation(unittest.TestCase):
     def _build_client(self):
         return Skyflow.builder().add_vault_config(VALID_VAULT_CONFIG).build()

--- a/tests/client/test_skyflow.py
+++ b/tests/client/test_skyflow.py
@@ -442,9 +442,8 @@ class TestBearerTokenContextAndRolesEndToEnd(unittest.TestCase):
         vault_client.initialize_client_configuration()
         return mock_gen.call_args[0][1]
 
-    @patch("skyflow.vault.client.client.Skyflow")
     @patch("skyflow.vault.client.client.generate_bearer_token_from_creds", return_value=("token", "bearer"))
-    def test_string_context_and_roles_reach_token_engine(self, mock_gen, _mock_api):
+    def test_string_context_and_roles_reach_token_engine(self, mock_gen):
         options = self._build_and_generate(
             {
                 "credentials_string": self.CREDENTIALS_STRING,
@@ -456,9 +455,8 @@ class TestBearerTokenContextAndRolesEndToEnd(unittest.TestCase):
         self.assertEqual(options["role_ids"], ["role_id_1", "role_id_2"])
         self.assertEqual(options["ctx"], "user_12345")
 
-    @patch("skyflow.vault.client.client.Skyflow")
     @patch("skyflow.vault.client.client.generate_bearer_token_from_creds", return_value=("token", "bearer"))
-    def test_dict_context_reaches_token_engine(self, mock_gen, _mock_api):
+    def test_dict_context_reaches_token_engine(self, mock_gen):
         options = self._build_and_generate(
             {
                 "credentials_string": self.CREDENTIALS_STRING,

--- a/tests/utils/validations/test__validations.py
+++ b/tests/utils/validations/test__validations.py
@@ -506,6 +506,19 @@ class TestValidations(unittest.TestCase):
             validate_delete_request(self.logger, request)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_RECORD_IDS_IN_DELETE.value)
 
+    def test_validate_delete_request_non_list_ids(self):
+        for ids in ["id1", 123, {"id": "id1"}, ("id1", "id2")]:
+            with self.subTest(ids=ids):
+                request = MagicMock()
+                request.table = "test_table"
+                request.ids = ids
+                with self.assertRaises(SkyflowError) as context:
+                    validate_delete_request(self.logger, request)
+                self.assertEqual(
+                    context.exception.message,
+                    SkyflowMessages.Error.INVALID_IDS_TYPE.value.format(type(ids))
+                )
+
     def test_validate_query_request_valid(self):
         request = MagicMock()
         request.query = "SELECT * FROM test_table"

--- a/tests/utils/validations/test__validations.py
+++ b/tests/utils/validations/test__validations.py
@@ -684,6 +684,20 @@ class TestValidations(unittest.TestCase):
             validate_update_request(self.logger, request)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_TABLE_VALUE.value)
 
+    def test_validate_update_request_non_string_skyflow_id(self):
+        for skyflow_id in [123, ["id123"], {"id": "id123"}]:
+            with self.subTest(skyflow_id=skyflow_id):
+                request = UpdateRequest(
+                    table="test_table",
+                    data={"skyflow_id": skyflow_id, "field1": "value1"}
+                )
+                with self.assertRaises(SkyflowError) as context:
+                    validate_update_request(self.logger, request)
+                self.assertEqual(
+                    context.exception.message,
+                    SkyflowMessages.Error.INVALID_SKYFLOW_ID_TYPE.value.format(type(skyflow_id))
+                )
+
     def test_validate_update_request_invalid_token_mode(self):
         request = UpdateRequest(
             table="test_table",
@@ -1587,6 +1601,29 @@ class TestValidations(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             validate_file_upload_request(self.logger, request)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.MISSING_FILE_SOURCE.value)
+
+    def test_validate_file_upload_request_non_string_fields(self):
+        cases = [
+            ("table", 123, SkyflowMessages.Error.INVALID_TABLE_VALUE.value),
+            ("table", ["test_table"], SkyflowMessages.Error.INVALID_TABLE_VALUE.value),
+            ("column_name", 123, SkyflowMessages.Error.INVALID_COLUMN_NAME.value.format(type(123))),
+            ("column_name", ["file_col"], SkyflowMessages.Error.INVALID_COLUMN_NAME.value.format(type([]))),
+            ("skyflow_id", 123, SkyflowMessages.Error.INVALID_SKYFLOW_ID_TYPE.value.format(type(123))),
+            ("file_name", 123, SkyflowMessages.Error.INVALID_FILE_NAME.value),
+        ]
+        for field, value, expected_message in cases:
+            with self.subTest(field=field, value=value):
+                kwargs = {
+                    "table": "test_table",
+                    "column_name": "file_col",
+                    "base64": "ZmlsZSBjb250ZW50",
+                    "file_name": "sample.txt",
+                    field: value,
+                }
+                request = FileUploadRequest(**kwargs)
+                with self.assertRaises(SkyflowError) as context:
+                    validate_file_upload_request(self.logger, request)
+                self.assertEqual(context.exception.message, expected_message)
 
     # --- validate_deidentify_text_request transformations ---
 

--- a/tests/utils/validations/test__validations.py
+++ b/tests/utils/validations/test__validations.py
@@ -13,7 +13,7 @@ from skyflow.utils.validations._validations import (
     validate_get_detect_run_request, validate_get_request, validate_update_request,
     validate_detokenize_request, validate_tokenize_request, validate_invoke_connection_params,
     validate_deidentify_text_request, validate_reidentify_text_request, validate_deidentify_file_request,
-    validate_file_upload_request
+    validate_file_upload_request, validate_token_options
 )
 from skyflow.utils import SkyflowMessages
 from skyflow.utils.enums import DetectEntities, RedactionType
@@ -209,20 +209,6 @@ class TestValidations(unittest.TestCase):
             SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format("vault", "vault123")
         )
 
-    def test_validate_vault_config_with_dict_context_and_roles(self):
-        from skyflow.utils.enums import Env
-        config = {
-            "vault_id": "vault123",
-            "cluster_id": "cluster123",
-            "credentials": {
-                "credentials_string": '{"clientID": "x"}',
-                "roles": ["role_id_1", "role_id_2"],
-                "context": {"role": "admin", "department": "finance"}
-            },
-            "env": Env.DEV
-        }
-        self.assertTrue(validate_vault_config(self.logger, config))
-
     # ------------------------------------------------------------------ #
     # credentials.roles                                                  #
     # ------------------------------------------------------------------ #
@@ -251,6 +237,21 @@ class TestValidations(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             validate_credentials(self.logger, credentials)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_ROLES.value)
+
+    # ------------------------------------------------------------------ #
+    # validate_token_options — shared by config validation and VaultClient #
+    # ------------------------------------------------------------------ #
+
+    def test_validate_token_options_rejects_empty_values(self):
+        """The contract VaultClient relies on; the cases themselves are covered above
+        via validate_credentials, which delegates here."""
+        with self.assertRaises(SkyflowError) as context:
+            validate_token_options(self.logger, {"roles": []})
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_ROLES.value)
+
+        with self.assertRaises(SkyflowError) as context:
+            validate_token_options(self.logger, {"context": {}})
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_CONTEXT.value)
 
     def test_validate_log_level_valid(self):
         from skyflow.utils.enums import LogLevel

--- a/tests/utils/validations/test__validations.py
+++ b/tests/utils/validations/test__validations.py
@@ -145,7 +145,113 @@ class TestValidations(unittest.TestCase):
             with self.assertRaises(SkyflowError) as context:
                 validate_credentials(self.logger, credentials)
             self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_CONTEXT.value)
-            
+
+    # ------------------------------------------------------------------ #
+    # credentials.context — string and dict/JSON object                  #
+    # ------------------------------------------------------------------ #
+
+    def test_validate_credentials_with_string_context(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "context": "user_12345"
+        }
+        validate_credentials(self.logger, credentials)
+
+    def test_validate_credentials_with_dict_context(self):
+        """A dict/JSON object context is accepted — the token engine supports it."""
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "context": {"role": "admin", "department": "finance"}
+        }
+        validate_credentials(self.logger, credentials)
+
+    def test_validate_credentials_with_empty_dict_context(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "context": {}
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_credentials(self.logger, credentials)
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_CONTEXT.value)
+
+    def test_validate_credentials_with_invalid_dict_context_key(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "context": {"invalid key": "value"}
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_credentials(self.logger, credentials)
+        self.assertEqual(
+            context.exception.message,
+            SkyflowMessages.Error.INVALID_CTX_MAP_KEY.value.format("invalid key")
+        )
+
+    def test_validate_credentials_with_invalid_context_type(self):
+        for invalid_context in [123, ["user_12345"], True]:
+            credentials = {
+                "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+                "context": invalid_context
+            }
+            with self.assertRaises(SkyflowError) as context:
+                validate_credentials(self.logger, credentials)
+            self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_CONTEXT.value)
+
+    def test_validate_credentials_with_dict_context_in_config(self):
+        """Config-scoped messages are used when a config id is available."""
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "context": {}
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_credentials(self.logger, credentials, "vault", "vault123")
+        self.assertEqual(
+            context.exception.message,
+            SkyflowMessages.Error.EMPTY_CONTEXT_IN_CONFIG.value.format("vault", "vault123")
+        )
+
+    def test_validate_vault_config_with_dict_context_and_roles(self):
+        from skyflow.utils.enums import Env
+        config = {
+            "vault_id": "vault123",
+            "cluster_id": "cluster123",
+            "credentials": {
+                "credentials_string": '{"clientID": "x"}',
+                "roles": ["role_id_1", "role_id_2"],
+                "context": {"role": "admin", "department": "finance"}
+            },
+            "env": Env.DEV
+        }
+        self.assertTrue(validate_vault_config(self.logger, config))
+
+    # ------------------------------------------------------------------ #
+    # credentials.roles                                                  #
+    # ------------------------------------------------------------------ #
+
+    def test_validate_credentials_with_roles(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "roles": ["role_id_1", "role_id_2"]
+        }
+        validate_credentials(self.logger, credentials)
+
+    def test_validate_credentials_with_invalid_roles_type(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "roles": "role_id_1"
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_credentials(self.logger, credentials)
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_ROLES_KEY_TYPE.value)
+
+    def test_validate_credentials_with_empty_roles(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "roles": []
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_credentials(self.logger, credentials)
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_ROLES.value)
+
     def test_validate_log_level_valid(self):
         from skyflow.utils.enums import LogLevel
         log_level = LogLevel.ERROR

--- a/tests/utils/validations/test__validations.py
+++ b/tests/utils/validations/test__validations.py
@@ -238,6 +238,15 @@ class TestValidations(unittest.TestCase):
             validate_credentials(self.logger, credentials)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_ROLES.value)
 
+    def test_validate_credentials_with_non_string_role_elements(self):
+        credentials = {
+            "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+            "roles": [None, 123, {"id": "x"}]
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_credentials(self.logger, credentials)
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_ROLE_ELEMENT_TYPE.value)
+
     # ------------------------------------------------------------------ #
     # validate_token_options — shared by config validation and VaultClient #
     # ------------------------------------------------------------------ #
@@ -414,6 +423,17 @@ class TestValidations(unittest.TestCase):
             validate_update_connection_config(self.logger, config)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_CONNECTION_URL.value.format("conn123"))
 
+    def test_validate_update_connection_config_invalid_credentials_includes_connection_id(self):
+        config = {
+            "connection_id": "conn123",
+            "connection_url": "https://example.com",
+            "credentials": {}
+        }
+        with self.assertRaises(SkyflowError) as context:
+            validate_update_connection_config(self.logger, config)
+        self.assertEqual(context.exception.message,
+            SkyflowMessages.Error.INVALID_CREDENTIALS_IN_CONFIG.value.format("connection", "conn123"))
+
     def test_validate_file_from_request_valid_file(self):
         file_obj = MagicMock()
         file_obj.name = "test.txt"
@@ -482,6 +502,20 @@ class TestValidations(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             validate_insert_request(self.logger, request)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.EMPTY_DATA_IN_INSERT.value)
+
+    def test_validate_insert_request_tokens_as_dict(self):
+        request = MagicMock()
+        request.table = "test_table"
+        request.values = [{"field1": "value1"}]
+        request.upsert = None
+        request.homogeneous = None
+        request.token_mode = None
+        request.return_tokens = False
+        request.continue_on_error = False
+        request.tokens = {"field1": "token1"}
+        with self.assertRaises(SkyflowError) as context:
+            validate_insert_request(self.logger, request)
+        self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_TYPE_OF_DATA_IN_INSERT.value)
 
 
     def test_validate_delete_request_valid(self):
@@ -728,8 +762,17 @@ class TestValidations(unittest.TestCase):
         request.continue_on_error = False
         with self.assertRaises(SkyflowError) as context:
             validate_detokenize_request(self.logger, request)
-        self.assertEqual(context.exception.message, 
+        self.assertEqual(context.exception.message,
             SkyflowMessages.Error.INVALID_TOKEN_TYPE.value.format("DETOKENIZE"))
+
+    def test_validate_detokenize_request_bare_string_data(self):
+        request = MagicMock()
+        request.data = ["mytoken123"]  # bare string containing 'token' as a substring
+        request.continue_on_error = False
+        with self.assertRaises(SkyflowError) as context:
+            validate_detokenize_request(self.logger, request)
+        self.assertEqual(context.exception.message,
+            SkyflowMessages.Error.INVALID_TOKENS_LIST_VALUE.value.format(list))
 
     def test_validate_tokenize_request_valid(self):
         request = MagicMock()

--- a/tests/utils/validations/test__validations.py
+++ b/tests/utils/validations/test__validations.py
@@ -186,15 +186,31 @@ class TestValidations(unittest.TestCase):
             SkyflowMessages.Error.INVALID_CTX_MAP_KEY.value.format("invalid key")
         )
 
-    def test_validate_credentials_with_invalid_context_type(self):
-        for invalid_context in [123, ["user_12345"], True]:
-            credentials = {
-                "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
-                "context": invalid_context
-            }
-            with self.assertRaises(SkyflowError) as context:
+    def test_validate_credentials_with_scalar_context(self):
+        """Numbers and booleans are valid ctx claims, so they must not be rejected here.
+
+        The token engine and the auth service both accept them; rejecting them would make the
+        client stricter than generate_bearer_token for no reason. Falsy scalars are included
+        because nothing on this path may test truthiness.
+        """
+        for scalar_context in [123, 0, 1.5, 0.0, True, False]:
+            with self.subTest(context=scalar_context):
+                credentials = {
+                    "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+                    "context": scalar_context
+                }
                 validate_credentials(self.logger, credentials)
-            self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_CONTEXT.value)
+
+    def test_validate_credentials_with_invalid_context_type(self):
+        for invalid_context in [["user_12345"], ("user_12345",), None, object()]:
+            with self.subTest(context=invalid_context):
+                credentials = {
+                    "api_key": "sky-abc12-1234567890abcdef1234567890abcdef",
+                    "context": invalid_context
+                }
+                with self.assertRaises(SkyflowError) as context:
+                    validate_credentials(self.logger, credentials)
+                self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_CONTEXT.value)
 
     def test_validate_credentials_with_dict_context_in_config(self):
         """Config-scoped messages are used when a config id is available."""

--- a/tests/vault/client/test__client.py
+++ b/tests/vault/client/test__client.py
@@ -9,15 +9,32 @@ CONFIG = {
     "credentials": "some_credentials",
     "cluster_id": "test_cluster_id",
     "env": "test_env",
-    "vault_id": "test_vault_id",
-    "roles": ["role_id_1", "role_id_2"],
-    "ctx": "context"
+    "vault_id": "test_vault_id"
 }
 
 CREDENTIALS_WITH_API_KEY = {"api_key": "dummy_api_key"}
 CREDENTIALS_WITH_TOKEN = {"token": "dummy_static_token"}
 CREDENTIALS_WITH_PATH = {"path": "/some/path/credentials.json"}
 CREDENTIALS_WITH_STRING = {"credentials_string": '{"clientID": "x"}'}
+
+ROLES = ["role_id_1", "role_id_2"]
+STRING_CONTEXT = "user_12345"
+DICT_CONTEXT = {"role": "admin", "department": "finance"}
+
+CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT = {
+    "path": "/some/path/credentials.json",
+    "roles": ROLES,
+    "context": STRING_CONTEXT,
+}
+CREDENTIALS_WITH_PATH_AND_DICT_CONTEXT = {
+    "path": "/some/path/credentials.json",
+    "context": DICT_CONTEXT,
+}
+CREDENTIALS_WITH_STRING_ROLES_AND_CONTEXT = {
+    "credentials_string": '{"clientID": "x"}',
+    "roles": ROLES,
+    "context": STRING_CONTEXT,
+}
 
 
 class TestVaultClient(unittest.TestCase):
@@ -296,6 +313,106 @@ class TestVaultClient(unittest.TestCase):
         result = self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH)
         mock_generate.assert_not_called()
         self.assertEqual(result, "valid_token")
+
+    # ------------------------------------------------------------------ #
+    # get_bearer_token — roles / context forwarded to the token engine   #
+    # ------------------------------------------------------------------ #
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
+    def test_get_bearer_token_forwards_roles_and_string_context_from_path_credentials(self, mock_generate):
+        """roles/context nested under credentials must reach the token engine options."""
+        self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT)
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertEqual(options["role_ids"], ROLES)
+        self.assertEqual(options["ctx"], STRING_CONTEXT)
+
+    @patch("skyflow.vault.client.client.generate_bearer_token_from_creds", return_value=("sa_token_str", None))
+    @patch("skyflow.vault.client.client.log_info")
+    def test_get_bearer_token_forwards_roles_and_context_from_credentials_string(self, mock_log, mock_generate):
+        self.vault_client.get_bearer_token(CREDENTIALS_WITH_STRING_ROLES_AND_CONTEXT)
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertEqual(options["role_ids"], ROLES)
+        self.assertEqual(options["ctx"], STRING_CONTEXT)
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
+    def test_get_bearer_token_forwards_dict_context_unmodified(self, mock_generate):
+        """A dict/JSON object context is passed through as-is."""
+        self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH_AND_DICT_CONTEXT)
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertEqual(options["ctx"], DICT_CONTEXT)
+        self.assertNotIn("role_ids", options)
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
+    def test_get_bearer_token_omits_options_when_roles_and_context_absent(self, mock_generate):
+        self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH)
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertNotIn("role_ids", options)
+        self.assertNotIn("ctx", options)
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
+    def test_get_bearer_token_ignores_top_level_config_roles_and_ctx(self, mock_generate):
+        """roles/ctx are only read from credentials — never from the top-level config."""
+        vault_client = VaultClient({**CONFIG, "roles": ["stale_role"], "ctx": "stale_ctx"})
+        vault_client.get_bearer_token(CREDENTIALS_WITH_PATH)
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertNotIn("role_ids", options)
+        self.assertNotIn("ctx", options)
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
+    def test_get_bearer_token_forwards_token_uri_alongside_roles_and_context(self, mock_generate):
+        credentials = {
+            **CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT,
+            "token_uri": "https://manage.skyflowapis.com/v1/auth/sa/oauth/token",
+        }
+        self.vault_client.get_bearer_token(credentials)
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertEqual(options["role_ids"], ROLES)
+        self.assertEqual(options["ctx"], STRING_CONTEXT)
+        self.assertEqual(options["token_uri"], credentials["token_uri"])
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("new_token", None))
+    @patch("skyflow.vault.client.client.is_expired", return_value=True)
+    @patch("skyflow.vault.client.client.log_info")
+    def test_get_bearer_token_forwards_roles_and_context_on_refresh(self, mock_log, mock_is_expired, mock_generate):
+        """Auto-refresh of an expired token must carry roles/context too, not just the first call."""
+        self.vault_client._VaultClient__bearer_token = "expired_token"
+        result = self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT)
+
+        self.assertEqual(result, "new_token")
+        _, options, _ = mock_generate.call_args[0]
+        self.assertEqual(options["role_ids"], ROLES)
+        self.assertEqual(options["ctx"], STRING_CONTEXT)
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("refreshed_token", None))
+    @patch("skyflow.vault.client.client.is_expired", return_value=True)
+    @patch("skyflow.vault.client.client.get_credentials")
+    @patch("skyflow.vault.client.client.get_vault_url")
+    @patch("skyflow.vault.client.client.VaultClient.initialize_api_client")
+    def test_initialize_client_configuration_refresh_preserves_roles_and_context(
+        self, mock_init_api_client, mock_get_vault_url, mock_get_credentials,
+        mock_is_expired, mock_generate
+    ):
+        """End-to-end refresh path through initialize_client_configuration keeps the options."""
+        mock_get_credentials.return_value = CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT
+        mock_get_vault_url.return_value = "https://test-vault-url.com"
+
+        # Warm client with an expired service account token
+        self.vault_client._VaultClient__api_client = MagicMock()
+        self.vault_client._VaultClient__is_static_token = False
+        self.vault_client._VaultClient__bearer_token = "expired_sa_token"
+        self.vault_client._VaultClient__credentials = CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT
+
+        self.vault_client.initialize_client_configuration()
+
+        _, options, _ = mock_generate.call_args[0]
+        self.assertEqual(options["role_ids"], ROLES)
+        self.assertEqual(options["ctx"], STRING_CONTEXT)
 
     # ------------------------------------------------------------------ #
     # update_config                                                        #

--- a/tests/vault/client/test__client.py
+++ b/tests/vault/client/test__client.py
@@ -353,6 +353,25 @@ class TestVaultClient(unittest.TestCase):
         self.assertNotIn("role_ids", options)
         self.assertNotIn("ctx", options)
 
+    @patch("skyflow.vault.client.client.generate_bearer_token")
+    def test_get_bearer_token_rejects_empty_roles(self, mock_generate):
+        """An empty roles list must not silently produce an unscoped token."""
+        credentials = {**CREDENTIALS_WITH_PATH, "roles": []}
+        with self.assertRaises(SkyflowError) as ctx:
+            self.vault_client.get_bearer_token(credentials)
+        self.assertEqual(ctx.exception.message, SkyflowMessages.Error.EMPTY_ROLES.value)
+        mock_generate.assert_not_called()
+
+    @patch("skyflow.vault.client.client.generate_bearer_token")
+    def test_get_bearer_token_rejects_empty_context(self, mock_generate):
+        """An empty context must not silently produce a context-less token."""
+        for empty_context in [{}, "", "   "]:
+            credentials = {**CREDENTIALS_WITH_PATH, "context": empty_context}
+            with self.assertRaises(SkyflowError) as ctx:
+                self.vault_client.get_bearer_token(credentials)
+            self.assertEqual(ctx.exception.message, SkyflowMessages.Error.EMPTY_CONTEXT.value)
+        mock_generate.assert_not_called()
+
     @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
     def test_get_bearer_token_ignores_top_level_config_roles_and_ctx(self, mock_generate):
         """roles/ctx are only read from credentials — never from the top-level config."""
@@ -375,19 +394,6 @@ class TestVaultClient(unittest.TestCase):
         self.assertEqual(options["role_ids"], ROLES)
         self.assertEqual(options["ctx"], STRING_CONTEXT)
         self.assertEqual(options["token_uri"], credentials["token_uri"])
-
-    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("new_token", None))
-    @patch("skyflow.vault.client.client.is_expired", return_value=True)
-    @patch("skyflow.vault.client.client.log_info")
-    def test_get_bearer_token_forwards_roles_and_context_on_refresh(self, mock_log, mock_is_expired, mock_generate):
-        """Auto-refresh of an expired token must carry roles/context too, not just the first call."""
-        self.vault_client._VaultClient__bearer_token = "expired_token"
-        result = self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH_ROLES_AND_STRING_CONTEXT)
-
-        self.assertEqual(result, "new_token")
-        _, options, _ = mock_generate.call_args[0]
-        self.assertEqual(options["role_ids"], ROLES)
-        self.assertEqual(options["ctx"], STRING_CONTEXT)
 
     @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("refreshed_token", None))
     @patch("skyflow.vault.client.client.is_expired", return_value=True)

--- a/tests/vault/client/test__client.py
+++ b/tests/vault/client/test__client.py
@@ -346,6 +346,27 @@ class TestVaultClient(unittest.TestCase):
         self.assertNotIn("role_ids", options)
 
     @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
+    def test_get_bearer_token_forwards_scalar_context_unmodified(self, mock_generate):
+        """Numbers and booleans reach the token engine as-is, with their type preserved.
+
+        A ctx of 123 and a ctx of "123" are different JWT claims, so a coercion here would
+        silently change which policies match. Falsy scalars are covered too - they must not
+        be dropped by a truthiness check.
+        """
+        for scalar_context in [123, 0, 1.5, 0.0, True, False]:
+            with self.subTest(context=scalar_context):
+                mock_generate.reset_mock()
+                self.vault_client._VaultClient__bearer_token = None
+                credentials = {**CREDENTIALS_WITH_PATH, "context": scalar_context}
+
+                self.vault_client.get_bearer_token(credentials)
+
+                _, options, _ = mock_generate.call_args[0]
+                self.assertEqual(options["ctx"], scalar_context)
+                # assertEqual alone would pass on True vs 1, so pin the exact type.
+                self.assertIs(type(options["ctx"]), type(scalar_context))
+
+    @patch("skyflow.vault.client.client.generate_bearer_token", return_value=("sa_token", None))
     def test_get_bearer_token_omits_options_when_roles_and_context_absent(self, mock_generate):
         self.vault_client.get_bearer_token(CREDENTIALS_WITH_PATH)
 

--- a/tests/vault/controller/_request_assertions.py
+++ b/tests/vault/controller/_request_assertions.py
@@ -1,0 +1,43 @@
+"""Shared assertions for what the controllers actually send to the generated REST client.
+
+The controller tests mock the API layer, so `assert_called_once()` on its own only proves the
+controller reached the API — never that it built the right request. These helpers close that
+gap: a wrong table name, a dropped field or a flipped flag has to fail a test.
+"""
+import json
+
+from skyflow.utils._version import SDK_VERSION
+from skyflow.utils.constants import SKY_META_DATA_HEADER, SdkMetricsKey, SdkPrefix
+
+# Identical on every call, and covered once by assert_sky_metadata instead of in every test.
+IGNORED_KWARGS = ("request_options",)
+
+
+def assert_request(test_case, api_mock, expected_kwargs, expected_args=None):
+    """Assert api_mock was called exactly once, with exactly this request.
+
+    Compares the whole kwargs dict rather than a subset, so a dropped or renamed parameter
+    fails too - not just a wrong value.
+    """
+    api_mock.assert_called_once()
+    args, kwargs = api_mock.call_args
+    if expected_args is not None:
+        test_case.assertEqual(args, expected_args)
+    actual_kwargs = {key: value for key, value in kwargs.items() if key not in IGNORED_KWARGS}
+    test_case.assertEqual(actual_kwargs, expected_kwargs)
+
+
+def assert_sky_metadata(test_case, additional_headers):
+    """Assert a sky-metadata header is present and names this SDK version."""
+    test_case.assertIn(SKY_META_DATA_HEADER, additional_headers)
+    metrics = json.loads(additional_headers[SKY_META_DATA_HEADER])
+    test_case.assertEqual(
+        metrics[SdkMetricsKey.SDK_NAME_VERSION],
+        SdkPrefix.SKYFLOW_PYTHON + SDK_VERSION
+    )
+
+
+def request_options_headers(api_mock):
+    """The additional_headers the controller passed in request_options."""
+    _, kwargs = api_mock.call_args
+    return kwargs["request_options"]["additional_headers"]

--- a/tests/vault/controller/test__connection.py
+++ b/tests/vault/controller/test__connection.py
@@ -6,6 +6,7 @@ from skyflow.error import SkyflowError
 from skyflow.utils import SkyflowMessages, parse_invoke_connection_response
 from skyflow.utils._utils import get_data_from_content_type, construct_invoke_connection_request
 from skyflow.utils.enums import RequestMethod, ContentType
+from skyflow.utils.constants import SKY_META_DATA_HEADER
 from skyflow.utils._version import SDK_VERSION
 from skyflow.vault.connection import InvokeConnectionRequest
 from skyflow.vault.controller import Connection
@@ -70,6 +71,13 @@ class TestConnection(unittest.TestCase):
         self.mock_vault_client.get_bearer_token.assert_called_once()
         mock_get_credentials.assert_called_once()
 
+        # Assert the request actually sent - method, url with query params, body, content type
+        sent_request = mock_send.call_args[0][0]
+        self.assertEqual(sent_request.method, "POST")
+        self.assertEqual(sent_request.url, "https://connection_url/?query_key=value")
+        self.assertEqual(sent_request.body, json.dumps(VALID_BODY))
+        self.assertEqual(sent_request.headers['content-type'], "application/json")
+
     @patch('skyflow.vault.controller._connections.get_credentials')
     @patch('requests.Session.send')
     def test_invoke_with_x_skyflow_authorization_already_present(self, mock_send, mock_get_credentials):
@@ -83,16 +91,46 @@ class TestConnection(unittest.TestCase):
         mock_send.return_value = mock_response
 
         custom_auth = "custom_bearer_token"
+        # The guard compares against a lowercase literal, so any casing must be honoured
+        for header_key in ["x-skyflow-authorization", "X-Skyflow-Authorization", "X-SKYFLOW-AUTHORIZATION"]:
+            with self.subTest(header_key=header_key):
+                mock_send.reset_mock()
+                request = InvokeConnectionRequest(
+                    method=RequestMethod.POST,
+                    body=VALID_BODY,
+                    headers={header_key: custom_auth}
+                )
+
+                response = self.connection.invoke(request)
+
+                # Verify bearer token from vault_client is NOT used
+                self.assertIsNotNone(response)
+                sent_headers = mock_send.call_args[0][0].headers
+                self.assertEqual(sent_headers['x-skyflow-authorization'], custom_auth)
+                self.assertNotIn(VALID_BEARER_TOKEN, sent_headers.values())
+
+    @patch('skyflow.vault.controller._connections.get_credentials')
+    @patch('requests.Session.send')
+    def test_invoke_injects_bearer_token_when_header_absent(self, mock_send, mock_get_credentials):
+        """Test that the SDK-generated bearer token is used when the caller supplies none."""
+        mock_get_credentials.return_value = {"api_key": "test_api_key"}
+
+        mock_response = Mock()
+        mock_response.status_code = SUCCESS_STATUS_CODE
+        mock_response.content = SUCCESS_RESPONSE_CONTENT
+        mock_response.headers = {'x-request-id': 'test-request-id'}
+        mock_send.return_value = mock_response
+
         request = InvokeConnectionRequest(
             method=RequestMethod.POST,
             body=VALID_BODY,
-            headers={"x-skyflow-authorization": custom_auth}
+            headers=VALID_HEADERS
         )
 
-        response = self.connection.invoke(request)
-        
-        # Verify bearer token from vault_client is NOT used
-        self.assertIsNotNone(response)
+        self.connection.invoke(request)
+
+        sent_headers = mock_send.call_args[0][0].headers
+        self.assertEqual(sent_headers['x-skyflow-authorization'], VALID_BEARER_TOKEN)
 
     @patch('skyflow.vault.controller._connections.get_credentials')
     def test_invoke_invalid_headers(self, mock_get_credentials):
@@ -239,9 +277,11 @@ class TestConnection(unittest.TestCase):
 
         response = self.connection.invoke(request)
         
-        # Verify get_metrics was called
+        # Verify get_metrics was called and its payload is on the sent request
         mock_get_metrics.assert_called_once()
         self.assertIsNotNone(response)
+        sent_headers = mock_send.call_args[0][0].headers
+        self.assertEqual(json.loads(sent_headers[SKY_META_DATA_HEADER]), {"sdk_version": SDK_VERSION})
 
     def test_parse_invoke_connection_response_error_from_client(self):
         mock_response = Mock(spec=requests.Response)

--- a/tests/vault/controller/test__detect.py
+++ b/tests/vault/controller/test__detect.py
@@ -4,16 +4,17 @@ import base64
 import os
 import tempfile
 from skyflow.error import SkyflowError
-from skyflow.generated.rest import WordCharacterCount
+from skyflow.generated.rest import WordCharacterCount, FileDataDeidentifyText, FileDataDeidentifyAudio, Format
 from skyflow.utils import SkyflowMessages
 from skyflow.vault.controller import Detect
 from skyflow.vault.detect import DeidentifyTextRequest, ReidentifyTextRequest, \
     TokenFormat, DateTransformation, Transformations, DeidentifyFileRequest, GetDetectRunRequest, \
-    DeidentifyFileResponse, FileInput
+    DeidentifyFileResponse, FileInput, Bleep
 from skyflow.utils.enums import DetectEntities, TokenType
 import io
 
 from skyflow.vault.detect._file import File
+from tests.vault.controller._request_assertions import assert_request
 
 VAULT_ID = "test_vault_id"
 
@@ -65,7 +66,26 @@ class TestDetect(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
-        detect_api.deidentify_string.assert_called_once()
+
+        # Assert the text, entity list and token format reach the API
+        assert_request(
+            self,
+            detect_api.deidentify_string,
+            {
+                "vault_id": VAULT_ID,
+                "text": "John lives in NYC",
+                "entity_types": [DetectEntities.NAME],
+                "token_type": {
+                    "default": TokenType.ENTITY_ONLY,
+                    "entity_unq_counter": None,
+                    "entity_only": None,
+                    "vault_token": None
+                },
+                "allow_regex": None,
+                "restrict_regex": None,
+                "transformations": None
+            }
+        )
 
     @patch("skyflow.vault.controller._detect.validate_reidentify_text_request")
     @patch("skyflow.vault.controller._detect.parse_reidentify_text_response")
@@ -76,10 +96,12 @@ class TestDetect(unittest.TestCase):
             'text': 'John lives in NYC'
         }
 
-        # Create request
+        # Create request - all three re-identification formats populated
         request = ReidentifyTextRequest(
             text="Token1 lives in Token2",
-            redacted_entities=[DetectEntities.NAME]
+            redacted_entities=[DetectEntities.NAME],
+            masked_entities=[DetectEntities.LOCATION],
+            plain_text_entities=[DetectEntities.EMAIL_ADDRESS]
         )
 
         # Mock detect API
@@ -92,7 +114,21 @@ class TestDetect(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
-        detect_api.reidentify_string.assert_called_once()
+
+        # Assert each entity list lands on the right re-identification format
+        assert_request(
+            self,
+            detect_api.reidentify_string,
+            {
+                "vault_id": VAULT_ID,
+                "text": "Token1 lives in Token2",
+                "format": Format(
+                    redacted=[DetectEntities.NAME],
+                    masked=[DetectEntities.LOCATION],
+                    plaintext=[DetectEntities.EMAIL_ADDRESS]
+                )
+            }
+        )
 
     @patch("skyflow.vault.controller._detect.validate_deidentify_text_request")
     def test_deidentify_text_handles_generic_error(self, mock_validate):
@@ -165,9 +201,28 @@ class TestDetect(unittest.TestCase):
             result = self.detect.deidentify_file(req)
 
             mock_validate.assert_called_once()
-            files_api.deidentify_text.assert_called_once()
             mock_poll.assert_called_once()
             mock_parse.assert_called_once()
+
+            # Assert the encoded file and detect options reach the txt endpoint
+            assert_request(
+                self,
+                files_api.deidentify_text,
+                {
+                    "vault_id": VAULT_ID,
+                    "file": FileDataDeidentifyText(base_64="dGVzdCBjb250ZW50", data_format="txt"),
+                    "entity_types": [],
+                    "token_type": {
+                        "default": req.token_format.default,
+                        "entity_unq_counter": req.token_format.entity_unique_counter,
+                        "entity_only": req.token_format.entity_only,
+                        "vault_token": req.token_format.vault_token
+                    },
+                    "allow_regex": [],
+                    "restrict_regex": [],
+                    "transformations": None
+                }
+            )
 
             self.assertIsInstance(result, DeidentifyFileResponse)
             self.assertEqual(result.status, "SUCCESS")
@@ -195,7 +250,12 @@ class TestDetect(unittest.TestCase):
         file_obj.read.return_value = file_content
         file_obj.name = "audio.mp3"
         mock_base64.b64encode.return_value = b"YXVkaW8gYnl0ZXM="
-        req = DeidentifyFileRequest(file=FileInput(file=file_obj))
+        bleep = Bleep(gain=0.5, frequency=800.0, start_padding=0.1, stop_padding=0.2)
+        req = DeidentifyFileRequest(
+            file=FileInput(file=file_obj),
+            bleep=bleep,
+            output_processed_audio=True
+        )
         req.entities = []
         req.token_format = Mock(default="default", entity_unique_counter=[], entity_only=[])
         req.allow_regex_list = []
@@ -226,9 +286,34 @@ class TestDetect(unittest.TestCase):
                                                                  status="SUCCESS")) as mock_parse:
             result = self.detect.deidentify_file(req)
             mock_validate.assert_called_once()
-            files_api.deidentify_audio.assert_called_once()
             mock_poll.assert_called_once()
             mock_parse.assert_called_once()
+
+            # Assert the audio-only options - bleep settings and transcription flags - are sent
+            assert_request(
+                self,
+                files_api.deidentify_audio,
+                {
+                    "vault_id": VAULT_ID,
+                    "file": FileDataDeidentifyAudio(base_64="YXVkaW8gYnl0ZXM=", data_format="mp3"),
+                    "entity_types": [],
+                    "token_type": {
+                        "default": req.token_format.default,
+                        "entity_unq_counter": req.token_format.entity_unique_counter,
+                        "entity_only": req.token_format.entity_only,
+                        "vault_token": req.token_format.vault_token
+                    },
+                    "allow_regex": [],
+                    "restrict_regex": [],
+                    "transformations": None,
+                    "output_transcription": None,
+                    "output_processed_audio": True,
+                    "bleep_gain": 0.5,
+                    "bleep_frequency": 800.0,
+                    "bleep_start_padding": 0.1,
+                    "bleep_stop_padding": 0.2
+                }
+            )
             self.assertIsInstance(result, DeidentifyFileResponse)
             self.assertEqual(result.status, "SUCCESS")
 
@@ -267,8 +352,15 @@ class TestDetect(unittest.TestCase):
                                                               run_id="runid789", status="SUCCESS")) as mock_parse:
             result = self.detect.get_detect_run(req)
             mock_validate.assert_called_once()
-            files_api.get_run.assert_called_once()
             mock_parse.assert_called_once()
+
+            # Assert the run id is the one looked up
+            assert_request(
+                self,
+                files_api.get_run,
+                {"vault_id": VAULT_ID},
+                expected_args=("runid789",)
+            )
             self.assertIsInstance(result, DeidentifyFileResponse)
             self.assertEqual(result.status, "SUCCESS")
 
@@ -685,8 +777,29 @@ class TestDetect(unittest.TestCase):
 
             mock_file.read.assert_called_once()
             mock_validate.assert_called_once()
-            files_api.deidentify_text.assert_called_once()
             mock_basename.assert_called_with("/path/to/test.txt")
+            # The file_path branch encodes the file read off disk, same shape as file_object
+            assert_request(
+                self,
+                files_api.deidentify_text,
+                {
+                    "vault_id": VAULT_ID,
+                    "file": FileDataDeidentifyText(
+                        base_64="dGVzdCBjb250ZW50IGZyb20gZmlsZSBwYXRo",
+                        data_format="txt"
+                    ),
+                    "entity_types": [],
+                    "token_type": {
+                        "default": req.token_format.default,
+                        "entity_unq_counter": req.token_format.entity_unique_counter,
+                        "entity_only": req.token_format.entity_only,
+                        "vault_token": req.token_format.vault_token
+                    },
+                    "allow_regex": [],
+                    "restrict_regex": [],
+                    "transformations": None
+                }
+            )
             mock_poll.assert_called_once()
             mock_parse.assert_called_once()
 

--- a/tests/vault/controller/test__vault.py
+++ b/tests/vault/controller/test__vault.py
@@ -9,6 +9,7 @@ from skyflow.vault.data import InsertRequest, InsertResponse, UpdateResponse, Up
 from skyflow.vault.tokens import DetokenizeRequest, DetokenizeResponse, TokenizeResponse, TokenizeRequest
 from skyflow.error import SkyflowError
 from skyflow.utils.validations import validate_file_upload_request
+from tests.vault.controller._request_assertions import assert_request, assert_sky_metadata, request_options_headers
 VAULT_ID = "test_vault_id"
 TABLE_NAME = "test_table"
 
@@ -78,6 +79,18 @@ class TestVault(unittest.TestCase):
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response, True)
 
+        # Assert the request built for the API matches the expected batch body
+        assert_request(
+            self,
+            records_api.with_raw_response.record_service_batch_operation,
+            {
+                "records": expected_body,
+                "continue_on_error": True,
+                "byot": request.token_mode.value
+            },
+            expected_args=(VAULT_ID,)
+        )
+
         # Assert that the result matches the expected InsertResponse
         self.assertEqual(result.inserted_fields, expected_inserted_fields)
         self.assertEqual(result.errors, expected_errors)
@@ -122,6 +135,20 @@ class TestVault(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response, False)
+
+        # Assert the request built for the API matches the expected bulk body
+        assert_request(
+            self,
+            records_api.with_raw_response.record_service_insert_record,
+            {
+                "records": expected_body,
+                "tokenization": request.return_tokens,
+                "upsert": request.upsert,
+                "homogeneous": request.homogeneous,
+                "byot": request.token_mode.value
+            },
+            expected_args=(VAULT_ID, TABLE_NAME)
+        )
 
         # Assert that the result matches the expected InsertResponse
         self.assertEqual(result.inserted_fields, expected_inserted_fields)
@@ -181,6 +208,20 @@ class TestVault(unittest.TestCase):
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response, False)
 
+        # Assert the request built for the API matches the expected bulk body
+        assert_request(
+            self,
+            records_api.with_raw_response.record_service_insert_record,
+            {
+                "records": expected_body,
+                "tokenization": request.return_tokens,
+                "upsert": request.upsert,
+                "homogeneous": request.homogeneous,
+                "byot": request.token_mode.value
+            },
+            expected_args=(VAULT_ID, TABLE_NAME)
+        )
+
         # Assert that the result matches the expected InsertResponse
         self.assertEqual(result.inserted_fields, expected_inserted_fields)
         self.assertEqual(result.errors, None)  # No errors expected
@@ -222,6 +263,19 @@ class TestVault(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
+
+        # Assert the request built for the API strips skyflow_id out of the record fields
+        assert_request(
+            self,
+            records_api.record_service_update_record,
+            {
+                "id": "12345",
+                "record": expected_record,
+                "tokenization": request.return_tokens,
+                "byot": request.token_mode.value
+            },
+            expected_args=(VAULT_ID, TABLE_NAME)
+        )
 
         # Check that the result matches the expected UpdateResponse
         self.assertEqual(result.updated_field, expected_updated_field)
@@ -272,6 +326,14 @@ class TestVault(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
+
+        # Assert the request built for the API carries the ids to delete
+        assert_request(
+            self,
+            records_api.record_service_bulk_delete_record,
+            {"skyflow_ids": expected_payload},
+            expected_args=(VAULT_ID, TABLE_NAME)
+        )
 
         # Check that the result matches the expected DeleteResponse
         self.assertEqual(result.deleted_ids, expected_deleted_ids)
@@ -346,6 +408,14 @@ class TestVault(unittest.TestCase):
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
 
+        # Assert the request built for the API carries every get parameter
+        assert_request(
+            self,
+            records_api.record_service_bulk_get_record,
+            expected_payload,
+            expected_args=(VAULT_ID,)
+        )
+
         # Check that the result matches the expected GetResponse
         self.assertEqual(result.data, expected_data)
         self.assertEqual(result.errors, None)  # No errors expected
@@ -363,10 +433,16 @@ class TestVault(unittest.TestCase):
             column_name='email'
         )
 
-        # Expected payload
+        # Expected payload - ids/fields/paging are absent on a column lookup
         expected_payload = {
             "object_name": request.table,
+            "skyflow_ids": None,
+            "redaction": request.redaction_type.value,
             "tokenization": request.return_tokens,
+            "fields": None,
+            "offset": None,
+            "limit": None,
+            "download_url": None,
             "column_name": request.column_name,
             "column_values": request.column_values
         }
@@ -395,7 +471,13 @@ class TestVault(unittest.TestCase):
 
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
-        records_api.record_service_bulk_get_record.assert_called_once()
+        # Assert the request built for the API looks the record up by column, not by id
+        assert_request(
+            self,
+            records_api.record_service_bulk_get_record,
+            expected_payload,
+            expected_args=(VAULT_ID,)
+        )
 
         # Check that the result matches the expected GetResponse
         self.assertEqual(result.data, expected_data)
@@ -446,9 +528,28 @@ class TestVault(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
 
+        # Assert the query string reaches the API unaltered
+        assert_request(
+            self,
+            query_api.query_service_execute_query,
+            {"query": "SELECT * FROM test_table"},
+            expected_args=(VAULT_ID,)
+        )
+
         # Check that the result matches the expected QueryResponse
         self.assertEqual(result.fields, expected_fields)
         self.assertEqual(result.errors, None)  # No errors expected
+
+    @patch("skyflow.vault.controller._vault.validate_query_request")
+    @patch("skyflow.vault.controller._vault.parse_query_response")
+    def test_request_carries_sky_metadata_header(self, mock_parse_response, mock_validate):
+        """Every controller call attaches the sky-metadata header naming this SDK version."""
+        query_api = self.vault_client.get_query_api.return_value
+        query_api.query_service_execute_query.return_value = Mock()
+
+        self.vault.query(QueryRequest(query="SELECT * FROM test_table"))
+
+        assert_sky_metadata(self, request_options_headers(query_api.query_service_execute_query))
 
     @patch("skyflow.vault.controller._vault.validate_query_request")
     def test_query_handles_generic_error(self, mock_validate):
@@ -510,6 +611,17 @@ class TestVault(unittest.TestCase):
         # Assertions
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
+
+        # Assert every token and its redaction reach the API
+        assert_request(
+            self,
+            tokens_api.with_raw_response.record_service_detokenize,
+            {
+                "detokenization_parameters": expected_tokens_list,
+                "continue_on_error": False
+            },
+            expected_args=(VAULT_ID,)
+        )
 
         # Check that the result matches the expected DetokenizeResponse
         self.assertEqual(result.detokenized_fields, expected_fields)
@@ -582,6 +694,14 @@ class TestVault(unittest.TestCase):
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         mock_parse_response.assert_called_once_with(mock_api_response)
 
+        # Assert every value and its column group reach the API
+        assert_request(
+            self,
+            tokens_api.record_service_tokenize,
+            {"tokenization_parameters": expected_records_list},
+            expected_args=(VAULT_ID,)
+        )
+
         # Check that the result matches the expected TokenizeResponse
         self.assertEqual(result.tokenized_fields, expected_fields)
 
@@ -626,6 +746,19 @@ class TestVault(unittest.TestCase):
             result = self.vault.upload_file(request)
             mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
             mocked_open.assert_called_once_with("/path/to/test.txt", "rb")
+            # The file name is derived from the path and the bytes are read off disk
+            assert_request(
+                self,
+                records_api.with_raw_response.upload_file_v_2,
+                {
+                    "table_name": "test_table",
+                    "column_name": "file_column",
+                    "file": ("test.txt", b"test file content"),
+                    "skyflow_id": "123",
+                    "return_file_metadata": False
+                },
+                expected_args=(VAULT_ID,)
+            )
             self.assertEqual(result.skyflow_id, "123")
             self.assertIsNone(result.errors)
 
@@ -651,6 +784,19 @@ class TestVault(unittest.TestCase):
         # Call upload_file
         result = self.vault.upload_file(request)
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
+        # base64 is decoded to bytes and the caller-supplied file name is used
+        assert_request(
+            self,
+            records_api.with_raw_response.upload_file_v_2,
+            {
+                "table_name": "test_table",
+                "column_name": "file_column",
+                "file": ("test.txt", b"test file content"),
+                "skyflow_id": "123",
+                "return_file_metadata": False
+            },
+            expected_args=(VAULT_ID,)
+        )
         self.assertEqual(result.skyflow_id, "123")
         self.assertIsNone(result.errors)
 
@@ -679,6 +825,19 @@ class TestVault(unittest.TestCase):
         # Call upload_file
         result = self.vault.upload_file(request)
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
+        # The file object is forwarded as-is, named from its own .name attribute
+        assert_request(
+            self,
+            records_api.with_raw_response.upload_file_v_2,
+            {
+                "table_name": "test_table",
+                "column_name": "file_column",
+                "file": ("test.txt", mock_file),
+                "skyflow_id": "123",
+                "return_file_metadata": False
+            },
+            expected_args=(VAULT_ID,)
+        )
         self.assertEqual(result.skyflow_id, "123")
         self.assertIsNone(result.errors)
 
@@ -739,6 +898,19 @@ class TestVault(unittest.TestCase):
             result = self.vault.upload_file(request)
         mock_validate.assert_called_once_with(self.vault_client.get_logger(), request)
         self.assertIsNone(request.skyflow_id)
+        # skyflow_id is still sent, explicitly as None, so the vault generates one
+        assert_request(
+            self,
+            records_api.with_raw_response.upload_file_v_2,
+            {
+                "table_name": "test_table",
+                "column_name": "file_column",
+                "file": ("test.txt", b"test file content"),
+                "skyflow_id": None,
+                "return_file_metadata": False
+            },
+            expected_args=(VAULT_ID,)
+        )
         self.assertEqual(result.skyflow_id, "generated-id-123")
         self.assertIsNone(result.errors)
 


### PR DESCRIPTION
## SK-3039: Fix missing `roles`/`ctx` in bearer tokens and harden request/config input validation

### Problem
- `roles` and `context` set under `credentials` in `add_vault_config()` never reached the generated bearer token. `VaultClient.get_bearer_token()` read `roles`/`ctx` from the **top-level** config, but both are only accepted **nested under `credentials`** — top-level keys are rejected by `validate_keys`, so the lookup always resolved to `None`: no error, just a token with no `ctx` claim and no `role:` scope, on first generation and every auto-refresh.
- `context` was validated as `str` only, rejecting a dict/JSON object at `build()` even though the token-generation engine already supports it.
- Several request/config validators accepted the wrong Python type and either crashed with a raw, uncaught exception or silently produced wrong behaviour instead of raising a clean `SkyflowError`: dict `tokens` on insert, bare-string items in detokenize `data`, non-string elements in `roles`, non-list `ids` on delete, and non-string `skyflow_id`/`table`/`column_name`/`file_name` on update and file-upload.
- `validate_update_connection_config` dropped `connection_id` from `validate_credentials`, so credential errors on the update path lost config context that the add path already included.

### Changes
**Bearer token `roles`/`ctx`**
- `VaultClient.get_bearer_token()` now builds token options from the resolved `credentials` dict instead of the top-level config, and calls the shared `validate_token_options` directly — so a directly-constructed `VaultClient` can no longer skip roles/context validation. Keys are omitted when unset rather than passed as `None`.
- Fixes both first generation and every auto-refresh, for `path` and `credentials_string`, config-level and common credentials, and connection configs.
- `credentials.context` now accepts a `str`, `bool`, `int`, `float` & `dict`. Dict keys are validated at config time (`^[a-zA-Z0-9_]+$`), so an invalid key fails at `build()` instead of on the first API call. Empty dict is rejected as an empty context, matching existing empty-string behaviour.
- Fixed swapped `empty`/`invalid` error messages for `roles`: a non-list now reports "Specify roles as an array" instead of "Specify at least one role".
- `roles: []` now raises `EMPTY_ROLES` instead of silently producing an unscoped token. Each element of `roles` must now be a non-empty string, or validation raises — previously a non-string role was silently stringified into the OAuth scope.
- `validate_update_connection_config` now passes `connection_id` through to `validate_credentials`, so its error messages include the connection id like the add path already does.

**Insert / detokenize type safety**
- `InsertRequest(tokens=...)` with a non-list/non-dict-of-dicts value now raises `INVALID_TYPE_OF_DATA_IN_INSERT` instead of crashing in the diagnostic logging loop.
- `DetokenizeRequest(data=...)` with bare strings now always raises `INVALID_TOKENS_LIST_VALUE`, instead of only crashing when a string happened to contain `"token"` as a substring.

**Delete / update / file-upload validation**
- `DeleteRequest(ids=...)` with a non-list value now raises `INVALID_IDS_TYPE`.
- `UpdateRequest` and `FileUploadRequest` now type-check `skyflow_id` (new `INVALID_SKYFLOW_ID_TYPE` message), and `FileUploadRequest` type-checks `table`, `column_name`, and `file_name`, raising the existing corresponding error instead of crashing on `.strip()`.

### Behaviour change
`roles: []` and non-string `roles` elements previously passed validation and produced an unscoped or corrupted token; both now raise. Everything else is either a crash fix or a message correction — the accept/reject boundary for already-valid input is unchanged.

`roles` and `context` remain optional; validation only runs when the key is present.

### Tests
- `tests/vault/client/test__client.py`: string and dict context plus roles forwarded on the path and credentials-string flows; options omitted when unset; top-level config keys explicitly ignored; `token_uri` coexistence; refresh path verified directly and end-to-end through `initialize_client_configuration()`.
- `tests/utils/validations/test__validations.py`: string/dict context accepted, empty dict, invalid ctx key, invalid types, config-scoped message variant, end-to-end `validate_vault_config`, the three `roles` cases plus non-string role elements, dict `tokens` on insert, bare-string detokenize `data`, non-list delete `ids`, non-string `skyflow_id`/`table`/`column_name`/`file_name` on update and file-upload, and `connection_id` included in `validate_update_connection_config` error messages.
- `tests/client/test_skyflow.py`: end-to-end `builder().add_vault_config(...).build()` asserting the options handed to the token engine.
- Removed the stale top-level `roles`/`ctx` from the client test fixture — that shape is rejected by real validation.
