### PR TITLE
SK-2963: warn at startup when a beta/dev build targets a Production vault

### DIFF
--- a/skyflow/client/skyflow.py
+++ b/skyflow/client/skyflow.py
@@ -1,7 +1,7 @@
 from collections import OrderedDict
 from skyflow import LogLevel
 from skyflow.error import SkyflowError
-from skyflow.utils import SkyflowMessages
+from skyflow.utils import SkyflowMessages, SDK_VERSION, is_non_ga_version, any_vault_is_prod
 from skyflow.utils.logger import log_info, log_warn, set_active_log_level, Logger
 from skyflow.utils.constants import OptionField
 from skyflow.utils.validations import validate_vault_config, validate_connection_config, validate_update_vault_config, \
@@ -249,5 +249,8 @@ class Skyflow:
             self.__update_vault_client_logger(self.__log_level, self.__logger)
 
             self.__add_skyflow_credentials(self.__skyflow_credentials)
+
+            if is_non_ga_version(SDK_VERSION) and any_vault_is_prod(self.__vault_list):
+                log_warn(SkyflowMessages.Warning.BETA_BUILD_WARNING.value, self.__logger)
 
             return Skyflow(self)

--- a/skyflow/utils/__init__.py
+++ b/skyflow/utils/__init__.py
@@ -2,4 +2,4 @@ from ..utils.enums import LogLevel, Env, TokenType
 from ._skyflow_messages import SkyflowMessages
 from ._version import SDK_VERSION
 from ._helpers import get_base_url, format_scope, is_valid_url
-from ._utils import get_credentials, get_vault_url, construct_invoke_connection_request, get_metrics, parse_insert_response, handle_exception, parse_update_record_response, parse_delete_response, parse_detokenize_response, parse_tokenize_response, parse_query_response, parse_get_response, parse_invoke_connection_response, validate_api_key, encode_column_values, parse_deidentify_text_response, parse_reidentify_text_response, convert_detected_entity_to_entity_info 
+from ._utils import get_credentials, get_vault_url, construct_invoke_connection_request, get_metrics, parse_insert_response, handle_exception, parse_update_record_response, parse_delete_response, parse_detokenize_response, parse_tokenize_response, parse_query_response, parse_get_response, parse_invoke_connection_response, validate_api_key, encode_column_values, parse_deidentify_text_response, parse_reidentify_text_response, convert_detected_entity_to_entity_info, is_non_ga_version, any_vault_is_prod

--- a/skyflow/utils/_skyflow_messages.py
+++ b/skyflow/utils/_skyflow_messages.py
@@ -432,6 +432,11 @@ class SkyflowMessages:
             "Old positional order: (table, skyflow_id, column_name). "
             "New order: FileUploadRequest(table, column_name=..., skyflow_id=...)."
         )
+        BETA_BUILD_WARNING = (
+            f"{WARN}: [{error_prefix}] This is a beta/pre-release build of the Skyflow SDK (v{SDK_VERSION}). "
+            "Beta builds are intended for acceptance testing only - you appear to be connecting to a Production vault. "
+            "Contact your Skyflow representative before using this build in Production."
+        )
 
 
 

--- a/skyflow/utils/_utils.py
+++ b/skyflow/utils/_utils.py
@@ -20,9 +20,9 @@ from skyflow.utils.logger import log_error_log
 from skyflow.vault.detect import DeidentifyTextResponse, ReidentifyTextResponse
 from skyflow.vault.detect import EntityInfo, TextIndex
 from . import SkyflowMessages, SDK_VERSION
-from .constants import (PROTOCOL, HttpHeader, ApiKey, ContentType as ContentTypeConstants, 
-                        EncodingType, BooleanString, ResponseField, CredentialField, SdkPrefix, 
-                        SdkMetricsKey, ErrorDefaults, HttpStatusCode)
+from .constants import (PROTOCOL, HttpHeader, ApiKey, ContentType as ContentTypeConstants,
+                        EncodingType, BooleanString, ResponseField, CredentialField, SdkPrefix,
+                        SdkMetricsKey, ErrorDefaults, HttpStatusCode, ConfigField)
 from .enums import Env, ContentType, EnvUrls
 from skyflow.vault.data import InsertResponse, UpdateResponse, DeleteResponse, QueryResponse, GetResponse
 from .validations import validate_invoke_connection_params
@@ -64,6 +64,16 @@ def get_vault_url(cluster_id, env,vault_id, logger = None):
     protocol = PROTOCOL
 
     return f"{protocol}://{cluster_id}.{base_url}"
+
+# Beta/dev builds are published as <major>.<minor>.<patch>bN (PEP 440) or
+# <major>.<minor>.<patch>.dev0+<sha>; a plain public release has neither suffix.
+def is_non_ga_version(version):
+    return not bool(re.match(r'^\d+\.\d+\.\d+$', version or ''))
+
+def any_vault_is_prod(vault_configs):
+    # Unlike Java/Node/Go, env has no SDK-side default here - it's only ever
+    # PROD if the caller explicitly set it, so there's nothing to default.
+    return any(config.get(ConfigField.ENV) == Env.PROD for config in (vault_configs or []))
 
 def parse_path_params(url, path_params):
     result = url

--- a/tests/client/test_skyflow.py
+++ b/tests/client/test_skyflow.py
@@ -529,3 +529,52 @@ class TestFileUploadRequestDeprecation(unittest.TestCase):
         self.assertIsNone(req.base64)
         self.assertIsNone(req.file_object)
         self.assertIsNone(req.file_name)
+
+
+class TestSkyflowBetaBuildWarning(unittest.TestCase):
+    """SK-2963: warn at startup when a beta/dev build targets a Production vault."""
+
+    def setUp(self):
+        self.builder = Skyflow.builder()
+
+    @patch("skyflow.client.skyflow.SDK_VERSION", "99.0.0-beta.1")
+    def test_warns_for_non_ga_build_with_prod_vault(self):
+        prod_config = {**VALID_VAULT_CONFIG, "env": Env.PROD}
+        with patch("skyflow.client.skyflow.log_warn") as mock_warn:
+            self.builder.add_vault_config(prod_config).build()
+        mock_warn.assert_called_once()
+        self.assertIn("beta/pre-release build", mock_warn.call_args[0][0])
+
+    @patch("skyflow.client.skyflow.SDK_VERSION", "99.0.0-beta.1")
+    def test_warns_when_one_of_several_vaults_is_prod(self):
+        non_prod_config = {**VALID_VAULT_CONFIG, "vault_id": "OTHER_VAULT_ID", "env": Env.SANDBOX}
+        prod_config = {**VALID_VAULT_CONFIG, "env": Env.PROD}
+        with patch("skyflow.client.skyflow.log_warn") as mock_warn:
+            self.builder.add_vault_config(non_prod_config).add_vault_config(prod_config).build()
+        mock_warn.assert_called_once()
+        self.assertIn("beta/pre-release build", mock_warn.call_args[0][0])
+
+    @patch("skyflow.client.skyflow.SDK_VERSION", "99.0.0-beta.1")
+    def test_does_not_warn_when_no_vault_is_prod(self):
+        # VALID_VAULT_CONFIG uses env=DEV.
+        with patch("skyflow.client.skyflow.log_warn") as mock_warn:
+            self.builder.add_vault_config(VALID_VAULT_CONFIG).build()
+        for call in mock_warn.call_args_list:
+            self.assertNotIn("beta/pre-release build", call.args[0])
+
+    @patch("skyflow.client.skyflow.SDK_VERSION", "99.0.0-beta.1")
+    def test_does_not_warn_when_env_is_missing_entirely(self):
+        # Unlike Java/Node/Go, Python has no SDK-side default-to-PROD for a missing env.
+        config_without_env = {k: v for k, v in VALID_VAULT_CONFIG.items() if k != "env"}
+        with patch("skyflow.client.skyflow.log_warn") as mock_warn:
+            self.builder.add_vault_config(config_without_env).build()
+        for call in mock_warn.call_args_list:
+            self.assertNotIn("beta/pre-release build", call.args[0])
+
+    def test_does_not_warn_for_the_real_ga_version(self):
+        # SDK_VERSION is whatever this checkout's real, unpatched (GA) version is.
+        prod_config = {**VALID_VAULT_CONFIG, "env": Env.PROD}
+        with patch("skyflow.client.skyflow.log_warn") as mock_warn:
+            self.builder.add_vault_config(prod_config).build()
+        for call in mock_warn.call_args_list:
+            self.assertNotIn("beta/pre-release build", call.args[0])

--- a/tests/utils/test__utils.py
+++ b/tests/utils/test__utils.py
@@ -32,6 +32,8 @@ from skyflow.utils import (
     parse_deidentify_text_response,
     parse_reidentify_text_response,
     convert_detected_entity_to_entity_info,
+    is_non_ga_version,
+    any_vault_is_prod,
 )
 from skyflow.utils._utils import parse_path_params, to_lowercase_keys, get_metrics, handle_json_error, r_urlencode
 from skyflow.utils.enums import EnvUrls, Env, ContentType
@@ -96,6 +98,40 @@ class TestUtils(unittest.TestCase):
         with self.assertRaises(SkyflowError) as context:
             url = get_vault_url(valid_cluster_id, valid_env, valid_vault_id)
         self.assertEqual(context.exception.message, SkyflowMessages.Error.INVALID_ENV.value.format(valid_vault_id))
+
+    # SK-2963: beta-build-in-prod warning
+    def test_is_non_ga_version_plain_semver_is_ga(self):
+        self.assertFalse(is_non_ga_version("1.0.0"))
+        self.assertFalse(is_non_ga_version("2.11.3"))
+
+    def test_is_non_ga_version_beta_suffix_is_non_ga(self):
+        self.assertTrue(is_non_ga_version("2.1.0b1"))
+
+    def test_is_non_ga_version_dev_suffix_is_non_ga(self):
+        self.assertTrue(is_non_ga_version("2.1.3.dev0+5e4b2fb"))
+
+    def test_is_non_ga_version_none_or_empty_is_non_ga(self):
+        self.assertTrue(is_non_ga_version(None))
+        self.assertTrue(is_non_ga_version(""))
+
+    def test_is_non_ga_version_garbage_is_non_ga(self):
+        self.assertTrue(is_non_ga_version("v2"))
+
+    def test_any_vault_is_prod_empty_or_none_is_false(self):
+        self.assertFalse(any_vault_is_prod(None))
+        self.assertFalse(any_vault_is_prod([]))
+
+    def test_any_vault_is_prod_no_vault_is_prod(self):
+        configs = [{"env": Env.DEV}, {"env": Env.SANDBOX}, {"env": Env.STAGE}]
+        self.assertFalse(any_vault_is_prod(configs))
+
+    def test_any_vault_is_prod_one_of_many_is_prod(self):
+        configs = [{"env": Env.DEV}, {"env": Env.PROD}]
+        self.assertTrue(any_vault_is_prod(configs))
+
+    def test_any_vault_is_prod_missing_env_is_not_prod(self):
+        # Unlike Java/Node/Go, Python has no SDK-side default-to-PROD for a missing env.
+        self.assertFalse(any_vault_is_prod([{"vault_id": "v1"}]))
 
     @patch("skyflow.utils._utils.log_and_reject_error")
     def test_handle_json_error_with_dict_data(self, mock_log_and_reject_error):


### PR DESCRIPTION
## Summary

Corrective action from the Fifth Third Bank RCA (CUST-4287): a beta/pre-release SDK build ended up running in a customer's Production environment undetected. This adds a startup warning so that doesn't happen silently again.

Adds a WARN-level log, emitted once in `Skyflow.Builder.build()`, when:
- the SDK's own version (`SDK_VERSION`) is **non-GA** — any PEP 440 `bN` or `.devN+<sha>` suffix, and
- at least one configured vault's `env` is **explicitly `Env.PROD`**.

**Note on this SDK specifically:** unlike Java/Node/Go, Python has no SDK-side default-to-PROD for a missing `env` — `validate_vault_config` only validates `env` if the key is present at all, and samples always set it explicitly. So `any_vault_is_prod()` here only fires on an *explicit* `Env.PROD`, matching this SDK's real behavior rather than assuming a default that doesn't exist in this codebase.

## Changes

- `skyflow/utils/_utils.py`: `is_non_ga_version()` and `any_vault_is_prod()` — small pure functions, exported through `skyflow/utils/__init__.py` for direct unit testing.
- `skyflow/utils/_skyflow_messages.py`: new `SkyflowMessages.Warning.BETA_BUILD_WARNING`.
- `skyflow/client/skyflow.py`: wires the check into `Builder.build()`, right before constructing `Skyflow(self)`. Goes through the existing `log_warn(..., self.__logger)`, so it respects the configured log level exactly like the existing `UPDATE_LOG_LEVEL_DEPRECATED` warning does.

## Testing

- `tests/utils/test__utils.py`: unit tests for `is_non_ga_version` (GA/beta/dev/None/garbage) and `any_vault_is_prod` (empty, none-prod, one-of-many-prod, missing-env).
- `tests/client/test_skyflow.py` (`TestSkyflowBetaBuildWarning`): patches `skyflow.client.skyflow.SDK_VERSION` to a fake beta value and exercises the **real `build()` wiring end-to-end** — confirms it warns for an explicit PROD vault and for one-of-several, stays silent when no vault is PROD, stays silent when `env` is omitted entirely, and (unpatched) stays silent against this checkout's real GA version.

**Verification caveat:** I wasn't able to execute this repo's test suite in my sandbox — no `pip`/`venv` available and no way to install this project's dependencies (pydantic, httpx, cryptography, etc.) without sudo. I syntax-checked every changed file with `python -m py_compile` (all clean) and hand-verified the `is_non_ga_version` regex against the test cases with a dependency-free script, but **please run `pytest` / your CI on this PR before merging** — it hasn't had the equivalent of the full-suite verification the companion Java and Node PRs got.

## Related

- Cross-SDK design + task tracking: SK-2963 (this is the reference-pattern implementation for skyflow-java; skyflow-go/js/... follow the same shape in their own repos).
- SK-2977 owns the final public-facing message wording — the copy here is a placeholder pending that sign-off.

🤖 Generated with [Claude Code](https://claude.com/claude-code)