### PR TITLE
SK-2977:Add beta build disclaimer banner to README on release

### DIFF
--- a/.github/workflows/shared-build-and-deploy.yml
+++ b/.github/workflows/shared-build-and-deploy.yml
@@ -74,6 +74,7 @@ jobs:
 
           git add setup.py
           git add skyflow/utils/_version.py
+          git add README.md
 
           if [[ "${{ inputs.tag }}" == "internal" ]]; then
             VERSION="${{ steps.previoustag.outputs.tag }}.dev0+$(git rev-parse --short $GITHUB_SHA)"

--- a/ci-scripts/bump_version.sh
+++ b/ci-scripts/bump_version.sh
@@ -8,6 +8,7 @@ then
     sed -E "s/current_version = .+/current_version = '$SEMVER'/g" setup.py > tempfile && cat tempfile > setup.py && rm -f tempfile
     sed -E "s/SDK_VERSION = .+/SDK_VERSION = '$SEMVER'/g" skyflow/utils/_version.py > tempfile && cat tempfile > skyflow/utils/_version.py && rm -f tempfile
     sed -E "s/__version__ = .+/__version__ = '$SEMVER'/g" skyflow/generated/rest/version.py > tempfile && cat tempfile > skyflow/generated/rest/version.py && rm -f tempfile
+    ./ci-scripts/toggle_beta_banner.sh README.md "$SEMVER"
 
     echo --------------------------
     echo "Done, Package now at $1"

--- a/ci-scripts/toggle_beta_banner.sh
+++ b/ci-scripts/toggle_beta_banner.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+# Insert or remove the beta-release disclaimer banner in a README, based on
+# whether the given version string is a pre-release build (PEP 440 syntax:
+# a pre-release identifier with no separating hyphen, e.g. "2.1.0b1").
+#
+# Usage: ci-scripts/toggle_beta_banner.sh <readme-path> <version>
+#
+# Idempotent: safe to run repeatedly against the same file and version.
+set -euo pipefail
+
+readme_path="$1"
+version="$2"
+
+marker_start="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+marker_end="<!-- SKYFLOW-BETA-DISCLAIMER:END -->"
+banner_body="> ⚠️ **Beta release — not for production use.** This is a pre-release build provided for early testing and feedback. It has not completed Skyflow's General Availability (GA) validation, its API may change before the stable release, and it is not covered by production SLAs or support commitments. Do not deploy beta builds to production environments."
+
+is_prerelease() {
+    [[ "$1" =~ ^[0-9]+\.[0-9]+\.[0-9]+(a|b|rc)[0-9]+ ]]
+}
+
+awk -v start="$marker_start" -v end="$marker_end" '
+    { lines[NR] = $0 }
+    END {
+        start_line = 0
+        end_line = 0
+        for (i = 1; i <= NR; i++) {
+            if (lines[i] == start) start_line = i
+            if (lines[i] == end) end_line = i
+        }
+        if (start_line == 0 || end_line == 0) {
+            del_from = -1
+            del_to = -1
+        } else {
+            del_from = start_line
+            del_to = end_line
+            if (del_from > 1 && lines[del_from - 1] == "") del_from--
+            if (del_to < NR && lines[del_to + 1] == "") del_to++
+        }
+        for (i = 1; i <= NR; i++) {
+            if (i >= del_from && i <= del_to) continue
+            print lines[i]
+        }
+    }
+' "$readme_path" > "${readme_path}.tmp"
+mv "${readme_path}.tmp" "$readme_path"
+
+if is_prerelease "$version"; then
+    awk -v start="$marker_start" -v body="$banner_body" -v end="$marker_end" '
+        NR == 1 {
+            print
+            print ""
+            print start
+            print body
+            print end
+            print ""
+            next
+        }
+        { print }
+    ' "$readme_path" > "${readme_path}.tmp"
+    mv "${readme_path}.tmp" "$readme_path"
+fi

--- a/ci-scripts/toggle_beta_banner.test.sh
+++ b/ci-scripts/toggle_beta_banner.test.sh
@@ -1,0 +1,34 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+TOGGLE="$SCRIPT_DIR/toggle_beta_banner.sh"
+FIXTURE="$(mktemp)"
+MARKER_START="<!-- SKYFLOW-BETA-DISCLAIMER:START -->"
+
+fail() {
+    echo "FAIL: $1"
+    rm -f "$FIXTURE"
+    exit 1
+}
+
+cat > "$FIXTURE" <<'EOF'
+# Skyflow Python SDK
+
+Python backend intro text.
+EOF
+
+# PEP 440 pre-release version (no hyphen) inserts the banner.
+"$TOGGLE" "$FIXTURE" "2.1.0b1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner not inserted for beta version"
+
+"$TOGGLE" "$FIXTURE" "2.1.0b1"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 1 ] || fail "banner duplicated on repeat run"
+
+"$TOGGLE" "$FIXTURE" "2.1.0"
+[ "$(grep -c -F "$MARKER_START" "$FIXTURE")" -eq 0 ] || fail "banner not removed for GA version"
+
+grep -qF "intro text." "$FIXTURE" || fail "original README content lost"
+
+rm -f "$FIXTURE"
+echo "PASS: toggle_beta_banner.sh"


### PR DESCRIPTION
## Summary
Adds a standard beta/pre-release disclaimer banner to the README, automatically toggled in and out by the existing release automation — part of the CUST-4287 RCA follow-up ([SK-2977](https://skyflow.atlassian.net/browse/SK-2977)).

- `ci-scripts/toggle_beta_banner.sh` inserts the banner right after the README's title when the version being released is a PEP 440 pre-release (e.g. `2.1.0b1`), and removes it on GA releases. Idempotent.
- Wired into `ci-scripts/bump_version.sh` (public/beta path only — internal/dev builds are unaffected) and `shared-build-and-deploy.yml` now stages `README.md` alongside `setup.py`/`_version.py` in its existing commit step.
- `ci-scripts/toggle_beta_banner.test.sh` covers insertion, idempotency, GA removal, and content preservation.

This is one of 8 sibling PRs (android, iOS, js, node, python, react-js, react-native, java) rolling out the same disclaimer text and mechanism across the SDKs. skyflow-go is deferred to a follow-up (no release CI to hook into today).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

[SK-2977]: https://skyflow.atlassian.net/browse/SK-2977?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ